### PR TITLE
Feature/group units year

### DIFF
--- a/django/university/models.py
+++ b/django/university/models.py
@@ -43,6 +43,17 @@ class CourseUnit(models.Model):
         unique_together = (('course_unit_id', 'course', 'year', 'semester'),)
 
 
+class DjangoMigrations(models.Model):
+    id = models.BigAutoField(primary_key=True)
+    app = models.CharField(max_length=255)
+    name = models.CharField(max_length=255)
+    applied = models.DateTimeField()
+
+    class Meta:
+        managed = False
+        db_table = 'django_migrations'
+
+
 class Faculty(models.Model):
     acronym = models.CharField(unique=True, max_length=10, blank=True, null=True)
     name = models.TextField(blank=True, null=True)

--- a/django/university/urls.py
+++ b/django/university/urls.py
@@ -5,6 +5,8 @@ from . import views
 urlpatterns = [
     path('faculty/', views.faculty),
     path('course/', views.course),
-    path('course_units/<int:course_id>/<int:semester>/', views.course_units),
+    path('course_units/<int:course_id>/<int:semester>/', views.course_units), 
+    path('course_units_by_year/<int:course_id>/<int:semester>/', views.course_units_by_year),
     path('schedule/<int:course_unit_id>/', views.schedule)
 ]
+    

--- a/django/university/urls.py
+++ b/django/university/urls.py
@@ -6,7 +6,8 @@ urlpatterns = [
     path('faculty/', views.faculty),
     path('course/', views.course),
     path('course_units/<int:course_id>/<int:semester>/', views.course_units), 
-    path('course_units_by_year/<int:course_id>/<int:semester>/', views.course_units_by_year),
+    path('course_units_by_year/<int:course_id>/<int:year>/<int:semester>/', views.course_units_by_year), 
+    path('course_last_year/<int:course_id>/', views.course_last_year),
     path('schedule/<int:course_unit_id>/', views.schedule)
 ]
     

--- a/django/university/views.py
+++ b/django/university/views.py
@@ -25,6 +25,25 @@ def course_units(request, course_id, semester):
     json_data = serializers.serialize('json', CourseUnit.objects.filter(course=course_id, semester=semester))
     return HttpResponse(json_data, content_type="application/json")
 
+@api_view(['GET'])
 def schedule(request, course_unit_id):
     json_data = serializers.serialize('json', Schedule.objects.filter(course_unit=course_unit_id))
     return HttpResponse(json_data, content_type="application/json")
+
+
+def course_units_by_year(request, course_id, semester): 
+    query_result = list(CourseUnit.objects.filter(course=course_id, semester=semester).order_by('course_year'))  
+    number_of_years = query_result[-1].course_year
+
+    res = []
+    for _ in range(number_of_years): 
+        res.append([])
+
+    print(res)
+    for course_unit in query_result: 
+        res[course_unit.course_year-1].append(course_unit) 
+
+    print(res)
+    json_data = serializers.serialize('json', res)   
+    return HttpResponse(json_data, content_type="application/json")
+

--- a/django/university/views.py
+++ b/django/university/views.py
@@ -6,6 +6,8 @@ from university.models import Schedule
 from django.http import JsonResponse
 from django.core import serializers
 from rest_framework.decorators import api_view
+from django.db.models import Max
+
 import json
 # Create your views here. 
 
@@ -16,34 +18,38 @@ def faculty(request):
 
 @api_view(['GET'])
 def course(request):
-    json_data = serializers.serialize('json', Course.objects.all())
-    return HttpResponse(json_data, content_type="application/json")
+    data_json = serializers.serialize('json', Course.objects.all()) 
+    return HttpResponse(data_json, content_type="application/json")
 
-
+"""
+    Return all the units from a course. 
+"""
 @api_view(['GET'])
-def course_units(request, course_id, semester):
-    json_data = serializers.serialize('json', CourseUnit.objects.filter(course=course_id, semester=semester))
+def course_units(request, course_id, semester): 
+    json_data = serializers.serialize('json', CourseUnit.objects.filter(course=course_id, semester=semester).order_by('year')) 
     return HttpResponse(json_data, content_type="application/json")
+
+"""
+    Returns the last year of a course.
+"""
+@api_view(['GET'])
+def course_last_year(request, course_id):
+    max_year = CourseUnit.objects.filter(course=course_id).aggregate(Max('course_year')).get('course_year__max')
+    json_data = {"max_year": max_year}
+    return JsonResponse(json_data)
+
+
+"""
+    Get all the units of a course in a certain year. 
+"""
+@api_view(['GET'])
+def course_units_by_year(request, course_id, year, semester): 
+    json_data = serializers.serialize(CourseUnit.objects.filter(course=course_id, semester=semester, year=year)) 
+    return HttpResponse(json_data, content_type="application/json")
+
 
 @api_view(['GET'])
 def schedule(request, course_unit_id):
     json_data = serializers.serialize('json', Schedule.objects.filter(course_unit=course_unit_id))
-    return HttpResponse(json_data, content_type="application/json")
-
-
-def course_units_by_year(request, course_id, semester): 
-    query_result = list(CourseUnit.objects.filter(course=course_id, semester=semester).order_by('course_year'))  
-    number_of_years = query_result[-1].course_year
-
-    res = []
-    for _ in range(number_of_years): 
-        res.append([])
-
-    print(res)
-    for course_unit in query_result: 
-        res[course_unit.course_year-1].append(course_unit) 
-
-    print(res)
-    json_data = serializers.serialize('json', res)   
     return HttpResponse(json_data, content_type="application/json")
 


### PR DESCRIPTION
In order to get unit courses by year, it was created a new endpoint to retrieve the last year of a course, which can be requested in the following way: 

```yaml
course_last_year/<int:course_id>/
```

Having the last year, the client can get the **course units** of a specific year: 

```yaml
course_units_by_year/<int:course_id>/<int:year>/<int:semester>/
```
