### PR TITLE
Change API and added cleaning

### DIFF
--- a/django/university/urls.py
+++ b/django/university/urls.py
@@ -5,7 +5,7 @@ from . import views
 urlpatterns = [
     path('faculty/', views.faculty),
     path('course/<int:year>', views.course),
-    path('course_units/<int:course_id>/<int:semester>/', views.course_units), 
+    path('course_units/<int:course_id>/<int:year>/<int:semester>/', views.course_units), 
     path('course_units_by_year/<int:course_id>/<int:year>/<int:semester>/', views.course_units_by_year), 
     path('course_last_year/<int:course_id>/', views.course_last_year),
     path('schedule/<int:course_unit_id>/', views.schedule)

--- a/django/university/urls.py
+++ b/django/university/urls.py
@@ -4,7 +4,7 @@ from . import views
 # URLConf
 urlpatterns = [
     path('faculty/', views.faculty),
-    path('course/', views.course),
+    path('course/<int:year>', views.course),
     path('course_units/<int:course_id>/<int:semester>/', views.course_units), 
     path('course_units_by_year/<int:course_id>/<int:year>/<int:semester>/', views.course_units_by_year), 
     path('course_last_year/<int:course_id>/', views.course_last_year),

--- a/django/university/views.py
+++ b/django/university/views.py
@@ -30,10 +30,11 @@ def course(request, year):
 
 """
     Return all the units from a course/major. 
+    REQUEST: course_units/<int:course_id>/<int:year>/<int:semester>/
 """
 @api_view(['GET'])
-def course_units(request, course_id, semester): 
-    json_data = list(CourseUnit.objects.filter(course=course_id, semester=semester).order_by('course_year').values())
+def course_units(request, course_id, year, semester): 
+    json_data = list(CourseUnit.objects.filter(course=course_id, semester=semester, year=year).order_by('course_year').values())
     return JsonResponse(json_data, safe=False)
 
 """

--- a/django/university/views.py
+++ b/django/university/views.py
@@ -20,11 +20,12 @@ def faculty(request):
     return HttpResponse(json_data, content_type="application/json")
 
 """
-    Returns all the major/major. 
+    Returns all the major/major.  
+    REQUEST: http://localhost:8000/course/<int:year>
 """
 @api_view(['GET'])
-def course(request):
-    json_data = list(Course.objects.values())
+def course(request, year):
+    json_data = list(Course.objects.filter(year=year).values())
     return JsonResponse(json_data, safe=False)
 
 """

--- a/mysql/sql/5_clean_database.sql
+++ b/mysql/sql/5_clean_database.sql
@@ -29,15 +29,31 @@ WHERE `id` IN (
 --
 -- Delete repeated theoretical classes: same day, duration, start_time, composed class name and course unit id
 --
-DELETE FROM `schedule`
-WHERE `lesson_type` = 'T'
-AND `id` NOT IN (
-	SELECT cid FROM (
-		SELECT min(`id`) AS cid
-		FROM `schedule` 
-		WHERE `lesson_type` = 'T' 
-		GROUP BY `day`, `duration`, `start_time`, `composed_class_name`, `course_unit_id`
-	) AS C
-);
+-- DELETE FROM `schedule`
+-- WHERE `lesson_type` = 'T'
+-- AND `id` NOT IN (
+--	SELECT cid FROM (
+--		SELECT min(`id`) AS cid
+--		FROM `schedule` 
+--		WHERE `lesson_type` = 'T' 
+--		GROUP BY `day`, `duration`, `start_time`, `composed_class_name`, `course_unit_id`
+--	) AS C
+-- );
+
+
+
+-- 
+-- Delete repeated classes: all fields are equal. 
+-- 
+
+create view `schedule2` as 
+  select min(id) 
+  from `schedule` 
+  group by `day`, `duration`, `start_time`, `location`, `lesson_type`, `teacher_acronym`, `course_unit_id`, `class_name`, `composed_class_name`;
+
+delete from `schedule` 
+where id not in (select * from schedule2);
+
+drop view schedule2;
 
 COMMIT; 


### PR DESCRIPTION
This pull request regards a few changes to make the time table selector reliable upon the misleading information that sigarra can provide. 

- [x] Although it was indicated to the scrapper to get the subjects from the year 2022, it still scraps information from the year 2021. Thus it must be provided to the API the year of the courses and classes. 
- [x] Multiple practical classes are being retrieved by the scrapper. Thus a pre-cleaning process to remove these was added. 