### PR TITLE
Refactor: course_units_api now searches courses and course_units through course_unit_year table

### DIFF
--- a/django/university/views.py
+++ b/django/university/views.py
@@ -3,7 +3,7 @@ from university.models import Faculty
 from university.models import Course
 from university.models import CourseUnit
 from university.models import Schedule
-from university.models import CourseUnitYear
+from university.models import CourseMetadata
 from django.http import JsonResponse
 from django.core import serializers
 from rest_framework.decorators import api_view
@@ -45,7 +45,7 @@ def course(request, year):
 @api_view(['GET'])
 def course_units(request, course_id, year, semester): 
     # Fetch CourseUnitYear model instances that match the attributes from the api url parameters.
-    course_unit_years = CourseUnitYear.objects.filter(course__id = course_id, course_unit__semester = semester, course__year = year).select_related('course_unit')
+    course_unit_years = CourseMetadata.objects.filter(course__id = course_id, course_unit__semester = semester, course__year = year).select_related('course_unit')
 
     json_data = list()
 
@@ -66,7 +66,7 @@ def course_units(request, course_id, year, semester):
 """
 @api_view(['GET'])
 def course_units_by_year(request, course_id, year, semester): 
-    course_unit_years = CourseUnitYear.objects.filter(course__id = course_id, course_unit__semester = semester, course__year = year).select_related('course_unit')
+    course_unit_years = CourseMetadata.objects.filter(course__id = course_id, course_unit__semester = semester, course__year = year).select_related('course_unit')
 
     json_data = list()
 
@@ -83,7 +83,7 @@ def course_units_by_year(request, course_id, year, semester):
 """
 @api_view(['GET'])
 def course_last_year(request, course_id):
-    max_year = CourseUnitYear.objects.filter(course__id=course_id).aggregate(Max('course_unit_year')).get('course_unit_year__max')
+    max_year = CourseMetadata.objects.filter(course__id=course_id).aggregate(Max('course_unit_year')).get('course_unit_year__max')
     json_data = {"max_year": max_year}
     return JsonResponse(json_data, safe=False)
 

--- a/mysql/sql/00_schema_mysql.sql
+++ b/mysql/sql/00_schema_mysql.sql
@@ -1,26 +1,16 @@
 -- phpMyAdmin SQL Dump
 -- version 4.7.7
--- https://www.phpmyadmin.net/
---
--- Host: db
--- Generation Time: Feb 04, 2018 at 01:27 PM
--- Server version: 5.7.20
--- PHP Version: 7.1.9
+
 
 SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
 SET AUTOCOMMIT = 0;
 START TRANSACTION;
 SET time_zone = "+00:00";
 
-
-/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
-/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
-/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8mb4 */;
-
 --
 -- Database: `tts`
 --
+
 
 CREATE TABLE `faculty` (
   `acronym` varchar(10) DEFAULT NULL,
@@ -37,16 +27,17 @@ CREATE TABLE `faculty` (
 
 CREATE TABLE `course` (
   `id` int(11) NOT NULL,
-  `faculty_acronym` varchar(10) NOT NULL,
-  `course_id` int(11) NOT NULL,
+  `sigarra_course_id` int(11) NOT NULL,
+  `faculty_id` varchar(10) NOT NULL,
   `name` varchar(200) NOT NULL,
   `acronym` varchar(10) NOT NULL,
-  `course_type` varchar(2) NOT NULL,
+  `course_type` varchar(2) NOT NULL,  
   `year` int(11) NOT NULL,
   `url` varchar(2000) NOT NULL,
   `plan_url` varchar(2000) NOT NULL,
   `last_updated` datetime NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
 
 -- --------------------------------------------------------
 
@@ -56,13 +47,12 @@ CREATE TABLE `course` (
 
 CREATE TABLE `course_unit` (
   `id` int(11) NOT NULL,
-  `course_unit_id` int(11) NOT NULL,
+  `sigarra_course_unit_id` int(11) NOT NULL,
   `course_id` int(11) NOT NULL,
   `name` varchar(200) NOT NULL,
   `acronym` varchar(16) NOT NULL,
   `url` varchar(2000) NOT NULL,
-  `course_year` tinyint(4) NOT NULL,
-  `semester` tinyint(4) NOT NULL,
+  `semester` int(4) NOT NULL,
   `year` smallint(6) NOT NULL,
   `schedule_url` varchar(2000) DEFAULT NULL,
   `last_updated` datetime NOT NULL
@@ -70,15 +60,18 @@ CREATE TABLE `course_unit` (
 
 -- --------------------------------------------------------
 
-
 --
--- Table structure for table `course_unit_year`
--- 
-CREATE TABLE `course_unit_year` (
-  `course_id` INTEGER NOT NULL,
-  `course_unit_id` int(11) NOT NULL, 
-  `course_unit_year` tinyint(4) NOT NULL
-);
+-- Table structure for table `course_metadata`
+--
+
+CREATE TABLE `course_metadata` (
+  `course_id` int(11) NOT NULL,
+  `course_unit_id` int(11) NOT NULL,
+  `course_unit_year` int(4) NOT NULL,
+  `ects` float(4) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+
 
 
 -- --------------------------------------------------------
@@ -87,53 +80,85 @@ CREATE TABLE `course_unit_year` (
 --
 
 CREATE TABLE `schedule` (
-  `id` int(11) NOT NULL,
-  `day` tinyint(3) UNSIGNED NOT NULL,
-  `duration` decimal(3,1) UNSIGNED NOT NULL,
-  `start_time` decimal(3,1) UNSIGNED NOT NULL,
+  `id` INTEGER NOT NULL,
+  `day` int(3) NOT NULL,
+  `duration` decimal(3,1) NOT NULL,
+  `start_time` decimal(3,1) NOT NULL,
   `location` varchar(31) NOT NULL,
   `lesson_type` varchar(3) NOT NULL,
-  `teacher_acronym` varchar(16) NOT NULL,
+  `is_composed` boolean NOT NULL,
+  `schedule_professor_id` INTEGER,
   `course_unit_id` int(11) NOT NULL,
   `last_updated` datetime NOT NULL,
   `class_name` varchar(31) NOT NULL,
   `composed_class_name` varchar(16) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+-- -------------------------------------------------------- 
+
+--
+-- Table structure for table `schedule_professor`
+--
+
+CREATE TABLE `schedule_professor` (
+  `schedule_id` INTEGER NOT NULL,
+  `professor_id` INTEGER NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+-- -------------------------------------------------------- 
+
+--
+-- Table structure for table `professor`
+--
+
+CREATE TABLE `professor` (
+  `id` INTEGER,
+  `professor_acronym` varchar(16),
+  `professor_name` varchar(50)
+);
+
+
 
 -- Add primary keys 
 alter TABLE faculty ADD PRIMARY KEY (`acronym`);
 
 alter TABLE course ADD PRIMARY KEY (`id`);
-alter TABLE course ADD FOREIGN KEY (faculty_acronym) REFERENCES faculty(acronym) on DELETE CASCADE ON UPDATE CASCADE;
+alter TABLE course ADD FOREIGN KEY (`faculty_id`) REFERENCES `faculty`(`acronym`) on DELETE CASCADE ON UPDATE CASCADE;
 
 alter TABLE course_unit ADD PRIMARY KEY (`id`);
 alter TABLE course_unit ADD FOREIGN KEY (`course_id`) REFERENCES `course`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
-alter TABLE course_unit_year ADD PRIMARY KEY (`course_id`, `course_unit_id`, `course_unit_year`);
-alter TABLE course_unit_year ADD FOREIGN KEY (`course_unit_id`) REFERENCES `course_unit`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
-alter TABLE course_unit_year ADD FOREIGN KEY (`course_id`) REFERENCES `course`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+alter TABLE course_metadata ADD PRIMARY KEY (`course_id`, `course_unit_id`, `course_unit_year`);
+alter TABLE course_metadata ADD FOREIGN KEY (`course_unit_id`) REFERENCES `course_unit`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+alter TABLE course_metadata ADD FOREIGN KEY (`course_id`) REFERENCES `course`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 alter TABLE schedule ADD PRIMARY KEY (`id`);
 alter TABLE schedule ADD FOREIGN KEY (`course_unit_id`) REFERENCES `course_unit`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 
--- Create index 
+alter TABLE schedule_professor ADD PRIMARY KEY (`schedule_id`, `professor_id`); 
+alter TABLE schedule_professor ADD FOREIGN KEY (`schedule_id`) REFERENCES `schedule`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
---
--- Indexes for dumped tables
---
+
+alter TABLE professor ADD PRIMARY KEY (`id`);
+alter TABLE schedule_professor ADD FOREIGN KEY (`professor_id`) REFERENCES `professor`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+alter TABLE schedule ADD FOREIGN KEY (`schedule_professor_id`) REFERENCES `professor`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+
+
+
+-- Create index 
 
 --
 -- Indexes for table `course`
 --
-CREATE UNIQUE INDEX `course_course_id` ON `course` (`course_id`,`faculty_acronym`,`year`);
-CREATE INDEX `course_faculty_acronym` ON `course` (`faculty_acronym`); 
+CREATE UNIQUE INDEX `course_course_id` ON `course` (`sigarra_course_id`,`faculty_id`,`year`);
+CREATE INDEX `course_faculty_acronym` ON `course` (`faculty_id`); 
 
 --
 -- Indexes for table `course_unit`
 --
-CREATE UNIQUE INDEX `course_unit_uniqueness` ON `course_unit`  (`course_unit_id`,`course_id`,`year`,`semester`); 
+CREATE UNIQUE INDEX `course_unit_uniqueness` ON `course_unit`  (`sigarra_course_unit_id`,`course_id`,`year`,`semester`); 
 CREATE INDEX `course_unit_course_id` ON `course_unit` (`course_id`);
 
 --
@@ -146,7 +171,8 @@ CREATE UNIQUE INDEX `faculty_acronym` ON `faculty`(`acronym`);
 --
 CREATE INDEX `schedule_course_unit_id` ON `schedule`(`course_unit_id`);
 
+--
+-- Indexes for table `course_metadata`
+-- 
+CREATE INDEX `course_metadata_index` ON `course_metadata`(`course_id`, `course_unit_id`, `course_unit_year`); 
 
-/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
-/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
-/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;


### PR DESCRIPTION
Closes #51 

*Note:* Currently, as the new modifications to the tables and the scrapper are not on the develop branch yet, when you are testing this, it is most likely that the course_unit_year table is empty on the local version of your database and that is probably the reason why if you run this backend version it will not work correctly as it will return an empty array if you're course_unit_year table is also empty.

# Why was this necessary 

*For future reference*

In order to address the planned changes in the database, it was necessary to now retrieve information about course units through the course_unit_year table as the same course unit can have more than one curricular year, instead of risking having more than one entry in the database about the same course unit where the only thing different would be the curricular year, which would happen with the old schema.

<hr>

# How was it done

Previously, in the django views ```course_units``` and ```course_units_by_year``` what was being retrieved was all the CourseUnit objects that matched the parameters passed to the view and in the ```course_last_year``` was searching through the course_units table.

The changes were

- Instead of using the CourseUnit model, the model used is now the CourseMetadata

- It now concatenates the dictionary of a certain course unit metadata instance and the dictionary of a the course unit
whose id is the same as in the course unit metadata

- In the ```course_last_year``` view now it searches the max course_year going through the course_unit_year table and not through the course_unit one.

# How was it tested

This was tested by creating two entries in the course_unit_year table that linked to the same course and course_unit but had different values for the ```course_year``` attribute and the result of the ```course_units api``` was correct. 

![image](https://user-images.githubusercontent.com/59887569/227172500-0854df2b-c0fe-4bb0-960d-9e8e314db5b1.png)

*Note:* In reality, this course unit does not have multiple years. It's just that way in this case because it was an hardcoded example.