### PR TITLE
Fixed docker compose configuration for arch

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,10 @@ services:
       - mysql/.env.dev
     ports:
       - 3306:3306
+    ulimits:
+      nofile:
+        soft: "262144"
+        hard: "262144"
 
   phpmyadmin:
     image: phpmyadmin:5.1.1-apache


### PR DESCRIPTION
Increased limit of numbers of files that can be simultaneously opened by the tts-be db process/container.

This fixes building tts-be for arch users.