### PR TITLE
Endpoint to return course unit based on id

### DIFF
--- a/django/university/response/errors.py
+++ b/django/university/response/errors.py
@@ -1,0 +1,5 @@
+def build_error_dict(msg: str) -> dict:
+    return {"error: ": msg}
+
+def course_unit_not_found_error(id: int) -> dict:
+    return build_error_dict(f"A course unit with id {id} was not found")

--- a/django/university/urls.py
+++ b/django/university/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     path('faculty/', views.faculty),
     path('course/<int:year>', views.course),
     path('course_units/<int:course_id>/<int:year>/<int:semester>/', views.course_units), 
+    path('course_unit/<int:course_unit_id>/', views.course_unit_by_id),
     path('class/<int:course_unit_id>/', views.classes),
     path('statistics/', views.data),
     path('professors/<int:slot>/', views.professor),

--- a/django/university/views.py
+++ b/django/university/views.py
@@ -9,16 +9,17 @@ from university.models import SlotProfessor
 from university.models import CourseMetadata
 from university.models import Statistics
 from university.models import Info
+from university.response.errors import course_unit_not_found_error
 from django.http import JsonResponse
 from django.core import serializers
 from rest_framework.decorators import api_view
+from rest_framework import status
 from django.db.models import Max
 from django.db import transaction
 import json
 import os 
 from django.utils import timezone
-# Create your views here. 
-
+from django.forms.models import model_to_dict
 
 def get_field(value):
     return value.field
@@ -36,6 +37,14 @@ def faculty(request):
 def course(request, year):
     json_data = list(Course.objects.filter(year=year).values())
     return JsonResponse(json_data, safe=False)
+
+@api_view(['GET'])
+def course_unit_by_id(request, course_unit_id):
+    course_unit = CourseUnit.objects.filter(id=course_unit_id).first()
+    if(course_unit == None):
+        return JsonResponse(course_unit_not_found_error(course_unit_id), status=status.HTTP_404_NOT_FOUND)
+
+    return JsonResponse(model_to_dict(course_unit), safe=False)
 
 """
     Return all the units from a course/major. 


### PR DESCRIPTION
This had to be done, since in order to have the paste course options functionality work on the frontend for courses different from the selected ones, we needed a way to retrieve a `CourseInfo` object from the backend and there were no endpoints available for that.