### PR TITLE
Fixes wrong command on README and more detail on django caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
-# TTS - backend
-The backend for timetable selector. 
+# TTS - Backend
+
+The backend for the timetable selector, which is a platform that aims to help students better choose their class schedules by allowing them to see and play with all possible combinations.
+
+Made with ❤️ by NIAEFEUP.
+
 ## Installation 
 ### Prerequisites
 - `docker`
-- `docker-compose` 
+- `docker compose` 
 
 ### Installing docker 
 to install docker, take a look on the [official website](https://www.docker.com/) and follow the [`Get docker`](https://docs.docker.com/get-docker/) section to install it. If you're using windows, make sure to have the [`wsl`](https://docs.microsoft.com/en-us/windows/wsl/install) installed.   
 
-In case you're using linux, after installing docker check the [`Manage Docker as a non-root user`](https://docs.docker.com/engine/install/linux-postinstall/), so you can use docker without the `sudo` command.  
+In case you're using linux, after installing docker check the [`Manage Docker as a non-root user`](https://docs.docker.com/engine/install/linux-postinstall/), so you can use docker without the `sudo` command, which involves creating a user group for docker.
 
 ## Data
 
-The data is available the NIAEFEUP drive (Only for NIAEFEUP members):
+The data is available at the NIAEFEUP drive (Only for NIAEFEUP members):
 
 https://drive.google.com/drive/folders/1hyiwPwwPWhbAPeJm03c0MAo1HTF6s_zK?usp=sharing
 
@@ -20,26 +24,36 @@ https://drive.google.com/drive/folders/1hyiwPwwPWhbAPeJm03c0MAo1HTF6s_zK?usp=sha
 
 - Copy the ```01_data.sql``` and ```00_schema_mysql.sql``` of year and semester you desire to the ```mysql/sql``` folder.
 
-
-
 ## Usage 
+
 ### Development environment 
-You can start developing by building the local server with docker:
+
+#### Building the container
+
+After you installed docker, go to the folder where you cloned this repository and do:
 
 ```yaml
-docker-compose build . 
+docker compose build
 ```
 
-In case you have __already build the server before and want to build it again__, be sure to delete the folder in `mysql/data`. You can do this by running `sudo rm -r mysql/data/`. To make your life easier, you can simply run the `build_dev.sh` script: `sudo ./build_dev.sh`.   
-> The sudo permission is nevessary to delete the `mysql/data` folder. 
+This will build the docker container for the backend.
+
+In case you have __already build the server before and want to repopulate the database__, make sure you run 
+
+```bash
+sudo make clean
+```
+
+We need to clean the database to repopulate it, since the way the mysql container works is that it only runs the `sql` files present in the `mysql/sql` folder if the database is clean. This is way we need to issue `sudo make clean` in order for the insert sql queries to be run.
+
+#### Running the container
 
 ```yaml
-docker-compose up 
+docker compose up 
 ```
+#### Some django caveats after running the container
 
-As well as the build, the running command can also be executed with the `run_dev.sh` script by executing: `./run_dev.sh`. 
- 
+- The first time you run this docker container or after you clean the database, you will need to a wait for some time (5-10 minutes) until the database is populated. It is normal to see django giving a `115` error since the database is not yet ready to anwser to connection requests since it is busy populating itself.
 
-> __WARNING__: it's likely that the first execution of `docker-compose up` after building won't work, since django doesn't wait for the database being populated to executed. Thus, if that's your ccase, execute it again. 
-
+- There are some times on the first execution of this command that django will start giving a`2` error. If that happens, you need to close the container with `docker compose down` and then turning it on with `docker compose up` again.
 


### PR DESCRIPTION
Closes #77 

### Here is a list of some of the problems this PR fixes:

- The command `docker compose build . ` didn't work

- There were references to scripts that no longer exist on the repository (for example, the `build_dev.sh`)