### PR TITLE
Fix schedule start time and duration types

### DIFF
--- a/django/university/controllers/ClassController.py
+++ b/django/university/controllers/ClassController.py
@@ -15,8 +15,8 @@ class ClassController:
             'id': slot_obj.id,
             'lesson_type': slot_obj.lesson_type,
             'day': slot_obj.day,
-            'start_time': slot_obj.start_time,
-            'duration': slot_obj.duration,
+            'start_time': float(slot_obj.start_time),
+            'duration': float(slot_obj.duration),
             'location': slot_obj.location,
             'is_composed': slot_obj.is_composed,
             'professors': professors


### PR DESCRIPTION
In Django, `NUMERIC` fields are parsed into strings instead of floats, which causes problems in frontend since it expects the fields `start_time` and `duration` of the slots to be of `number` type (either `integer` or `float`), like in conflict detection. This PR solves this problem by enforcing the type conversion to `float` when satissfying the request to the `class/` endpoint.