### PR TITLE
Chore: upgraded django and other dependencies

### DIFF
--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -1,5 +1,5 @@
 # deps
-FROM python:3.8-slim-buster AS deps
+FROM python:3.11-slim AS deps
 
 WORKDIR /usr/src/django/ 
 

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -1,10 +1,9 @@
-asgiref==3.4.1
-backports.zoneinfo==0.2.1
-Django==4.0
-django-cors-headers==3.10.1
-djangorestframework==3.11.0
+asgiref==3.8.1
+Django==5.1
+django-cors-headers==4.4.0
+djangorestframework==3.15.1
 pytz==2021.3
-sqlparse==0.4.2
+sqlparse==0.5.1
 psycopg2==2.9.9
 celery==5.2.7
 redis==3.5.3


### PR DESCRIPTION
Closes #100 

There is a lot of reported security vulnerabilities because of the outdated versions we keep using in our dependencies.

Moreover, having major dependencies outdated also harms us when we want to use a new feature because we will be restricted by the limitations of versions compatibilities.