### PR TITLE
Remove restart policy "always" from containers

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,6 @@ services:
     build:
       context: ./pgadmin
     container_name: tts_pgadmin
-    restart: always
     env_file:
       - pgadmin/.env.dev
     volumes:
@@ -47,7 +46,6 @@ services:
   redis_service:
     image: redis:6.2-bullseye
     container_name: tts_redis
-    restart: always
     ports:
       - "6379:6379"
 


### PR DESCRIPTION
When restart policy is set to always, the docker container will start every time the docker service is initiated (normally, after boot). This policy was used for the pgAdmin and Redis containers.

The problem is that this policy is irrelevant, as the server will always have to be initiated with the scripts and those containers are not set up on the cluster. Also, I noticed that the Redis container, in particular, was consuming a lot of battery power, so this simple change should give a slight boost to your battery life :smiley: 