### PR TITLE
Collaborative Sessions - Actually create a session [Backend]

### DIFF
--- a/django/tts_be/asgi.py
+++ b/django/tts_be/asgi.py
@@ -11,10 +11,10 @@ import os
 from django.core.asgi import get_asgi_application
 
 import socketio
-from university.socket.views import sio
+from university.socket.views import sessions_server
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tts_be.settings')
 
 django_app = get_asgi_application()
 
-application = socketio.ASGIApp(sio, django_app)
+application = socketio.ASGIApp(sessions_server.sio, django_app)

--- a/django/university/socket/participant.py
+++ b/django/university/socket/participant.py
@@ -1,9 +1,23 @@
+import uuid
+
 class Participant:
     def __init__(self, sid, name):
         self.sid = sid
+        self.client_id = str(uuid.uuid4())
         self.name = name
         
     def to_json(self):
         return {
+            'client_id': self.client_id,
             'name': self.name,
         }
+        
+    @staticmethod
+    def from_json(sid, data):
+        if 'name' not in data:
+            raise ValueError('name is required')
+        return Participant(sid, data['name'])
+    
+    def update_from_json(self, data):
+        if 'name' in data:
+            self.name = data['name']

--- a/django/university/socket/participant.py
+++ b/django/university/socket/participant.py
@@ -1,0 +1,9 @@
+class Participant:
+    def __init__(self, sid, name):
+        self.sid = sid
+        self.name = name
+        
+    def to_json(self):
+        return {
+            'name': self.name,
+        }

--- a/django/university/socket/session.py
+++ b/django/university/socket/session.py
@@ -1,11 +1,12 @@
 from university.socket.participant import Participant
 from datetime import datetime, timedelta, timezone
+import time
 
 class Session:
     def __init__(self, session_id: str, duration: timedelta = timedelta(days=30)):
         self.session_id = session_id
         self.participants = {}
-        self.expire_datetime = datetime.now(timezone.utc) + duration
+        self.expiration_datetime = datetime.now(timezone.utc) + duration
         
     def add_client(self, participant: Participant):
         self.participants[participant.sid] = participant
@@ -20,11 +21,11 @@ class Session:
         return self.participants == []
     
     def expired(self):
-        return datetime.now() > self.expire_datetime
+        return datetime.now() > self.expiration_datetime
     
     def to_json(self):
         return {
-            'expire_datetime': self.expire_datetime.strftime('%Y-%m-%d %H:%M:%S'),
+            'expiration_time': int(time.mktime(self.expiration_datetime.timetuple())) * 1000.0,
             'participants': list(map(Participant.to_json, self.participants.values()))
         }
     

--- a/django/university/socket/session.py
+++ b/django/university/socket/session.py
@@ -1,20 +1,21 @@
+from university.socket.participant import Participant
+
 class Session:
-    def __init__(self, session_id):
+    def __init__(self, session_id: str):
         self.session_id = session_id
-        self.clients = []
+        self.participants = {}
         
-    def add_client(self, client):
-        self.clients.append(client)
+    def add_client(self, participant: Participant):
+        self.participants[participant.sid] = participant
         
-    def remove_client(self, client):
-        self.clients.remove(client)
+    def remove_client(self, sid):
+        del self.participants[sid]
         
-    def is_empty(self):
-        return self.clients == []
+    def no_participants(self):
+        return self.participants == []
     
     def to_json(self):
         return {
-            'session_id': self.session_id,
-            'clients': self.clients,
+            'participants': list(map(Participant.to_json, self.participants.values()))
         }
     

--- a/django/university/socket/session.py
+++ b/django/university/socket/session.py
@@ -1,12 +1,11 @@
 from university.socket.participant import Participant
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 class Session:
     def __init__(self, session_id: str, duration: timedelta = timedelta(days=30)):
         self.session_id = session_id
         self.participants = {}
-        self.expire_datetime = datetime.now() + duration
+        self.expire_datetime = datetime.now(timezone.utc) + duration
         
     def add_client(self, participant: Participant):
         self.participants[participant.sid] = participant

--- a/django/university/socket/session.py
+++ b/django/university/socket/session.py
@@ -11,6 +11,9 @@ class Session:
     def remove_client(self, sid):
         del self.participants[sid]
         
+    def update_client(self, participant: Participant):
+        self.participants[participant.sid] = participant
+        
     def no_participants(self):
         return self.participants == []
     

--- a/django/university/socket/session.py
+++ b/django/university/socket/session.py
@@ -25,6 +25,7 @@ class Session:
     
     def to_json(self):
         return {
+            'expire_datetime': self.expire_datetime.strftime('%Y-%m-%d %H:%M:%S'),
             'participants': list(map(Participant.to_json, self.participants.values()))
         }
     

--- a/django/university/socket/session.py
+++ b/django/university/socket/session.py
@@ -1,9 +1,12 @@
 from university.socket.participant import Participant
+from datetime import datetime
+from datetime import timedelta
 
 class Session:
-    def __init__(self, session_id: str):
+    def __init__(self, session_id: str, duration: timedelta = timedelta(days=30)):
         self.session_id = session_id
         self.participants = {}
+        self.expire_datetime = datetime.now() + duration
         
     def add_client(self, participant: Participant):
         self.participants[participant.sid] = participant
@@ -16,6 +19,9 @@ class Session:
         
     def no_participants(self):
         return self.participants == []
+    
+    def expired(self):
+        return datetime.now() > self.expire_datetime
     
     def to_json(self):
         return {

--- a/django/university/socket/session.py
+++ b/django/university/socket/session.py
@@ -1,0 +1,20 @@
+class Session:
+    def __init__(self, session_id):
+        self.session_id = session_id
+        self.clients = []
+        
+    def add_client(self, client):
+        self.clients.append(client)
+        
+    def remove_client(self, client):
+        self.clients.remove(client)
+        
+    def is_empty(self):
+        return self.clients == []
+    
+    def to_json(self):
+        return {
+            'session_id': self.session_id,
+            'clients': self.clients,
+        }
+    

--- a/django/university/socket/sessionsserver.py
+++ b/django/university/socket/sessionsserver.py
@@ -18,8 +18,11 @@ class SessionsServer:
     def event(self, event):
         return self.sio.event(event)
     
-    def emit(self, event, data, to=None, session_id=None):
-        return self.sio.emit(event, data, to=to, room=session_id)
+    def emit(self, event, data, to):
+        return self.sio.emit(event, data, to=to)
+    
+    def emit_to_session(self, event, data, session_id, sid):
+        return self.sio.emit(event, data, room=session_id, skip_sid=sid)
     
     def generate_session_id(self):
         while True:

--- a/django/university/socket/sessionsserver.py
+++ b/django/university/socket/sessionsserver.py
@@ -1,6 +1,7 @@
 from typing import Coroutine
 from random import randbytes
 import socketio
+from socketio.exceptions import ConnectionRefusedError
 
 class SessionsServer:
     def __init__(self, sio: socketio.AsyncServer):
@@ -24,7 +25,7 @@ class SessionsServer:
     
     def create_session(self, sid) -> Coroutine:        
         if self.get_client_session(sid):
-            raise ConnectionError('Client is already in a session')
+            raise ConnectionRefusedError('Client is already in a session')
         
         session_id = self.generate_session_id()
         self.sessions.setdefault(session_id, [])
@@ -34,11 +35,11 @@ class SessionsServer:
     
     def enter_session(self, sid, session_id) -> Coroutine:
         if self.get_client_session(sid):
-            raise ConnectionError('Client is already in a session')
+            raise ConnectionRefusedError('Client is already in a session')
         
         if session_id not in self.sessions:
             print(self.sessions)
-            raise ConnectionError('Session is empty')
+            raise ConnectionRefusedError('Session is empty')
         
         return self.sio.enter_room(sid, session_id)
     

--- a/django/university/socket/sessionsserver.py
+++ b/django/university/socket/sessionsserver.py
@@ -3,10 +3,13 @@ from random import randbytes
 import socketio
 from socketio.exceptions import ConnectionRefusedError
 
+from university.socket.session import Session
+
 class SessionsServer:
     def __init__(self, sio: socketio.AsyncServer):
         self.sio = sio
         self.sessions = {}
+        self.clients = {}
 
     def valid_token(self, token: str) -> bool:
         return True
@@ -28,10 +31,14 @@ class SessionsServer:
             raise ConnectionRefusedError('Client is already in a session')
         
         session_id = self.generate_session_id()
-        self.sessions.setdefault(session_id, [])
-        self.sessions[session_id].append(sid)
+        result = self.sio.enter_room(sid, session_id)
         
-        return self.sio.enter_room(sid, session_id)
+        self.sessions.setdefault(session_id, Session(session_id))
+        self.sessions[session_id].add_client(sid)
+        self.clients[sid] = session_id
+        
+        return result
+        
     
     def enter_session(self, sid, session_id) -> Coroutine:
         if self.get_client_session(sid):
@@ -41,12 +48,30 @@ class SessionsServer:
             print(self.sessions)
             raise ConnectionRefusedError('Session is empty')
         
-        return self.sio.enter_room(sid, session_id)
+        self.sessions[session_id].add_client(sid)
+        result = self.sio.enter_room(sid, session_id)
+        
+        self.clients[sid] = session_id
+        
+        return result
     
     def leave_session(self, sid) -> Coroutine:
-        session_id = self.get_client_session(sid)
-        return self.sio.leave_room(sid, session_id)
+        session_id = self.clients.get(sid)
+        if session_id is None:
+            raise ConnectionRefusedError('Client is not in a session')
+        
+        result = self.sio.leave_room(sid, session_id)
+        
+        self.sessions[session_id].remove_client(sid)
+        if (self.sessions[session_id].is_empty()):
+            del self.sessions[session_id]
+
+        del self.clients[sid]
+
+        return result
     
-    def get_client_session(self, sid):
-        client_session = self.sio.rooms(sid)
-        return client_session[1] if len(client_session) >= 2 else None
+    def get_client_session(self, sid) -> Session | None:
+        return self.sessions.get(self.clients.get(sid))
+    
+    def get_session(self, session_id) -> Session | None:
+        return self.sessions.get(session_id)

--- a/django/university/socket/sessionsserver.py
+++ b/django/university/socket/sessionsserver.py
@@ -1,11 +1,50 @@
-import uuid
+from typing import Coroutine
+from random import randbytes
+import socketio
 
 class SessionsServer:
-    def __init__(self, sio):
+    def __init__(self, sio: socketio.AsyncServer):
         self.sio = sio
 
-    def valid_token(self, token):
+    def valid_token(self, token: str) -> bool:
         return True
         
     def event(self, event):
         return self.sio.event(event)
+    
+    def emit(self, event, data, **kwargs):
+        return self.sio.emit(event, data, **kwargs)
+    
+    def generate_room_id(self):
+        while True:
+            room_id = randbytes(2).hex().upper()
+            if room_id not in self.rooms:
+                return room_id
+    
+    def create_room(self, sid) -> Coroutine:        
+        if self.get_client_room(sid):
+            raise ConnectionError('Client is already in a room')
+        
+        room_id = self.generate_room_id()
+        return self.sio.enter_room(sid, room_id)
+    
+    def enter_room(self, sid, room_id) -> Coroutine:
+        if self.get_client_room(sid):
+            raise ConnectionError('Client is already in a room')
+        
+        if not self.sio.manager.rooms[room_id]:
+            raise ConnectionError('Room is empty')
+        
+        return self.sio.enter_room(sid, room_id)
+    
+    def leave_room(self, sid) -> Coroutine:
+        room_id = self.get_client_room(sid)
+        return self.sio.leave_room(sid, room_id)
+
+    @property
+    def rooms(self):
+        return self.sio.manager.rooms.keys()
+    
+    def get_client_room(self, sid):
+        client_room = self.sio.rooms(sid)
+        return client_room[1] if len(client_room) >= 2 else None

--- a/django/university/socket/sessionsserver.py
+++ b/django/university/socket/sessionsserver.py
@@ -67,7 +67,7 @@ class SessionsServer:
         result = self.sio.leave_room(sid, session_id)
         
         self.sessions[session_id].remove_client(sid)
-        if (self.sessions[session_id].no_participants()):
+        if self.sessions[session_id].no_participants() and self.sessions[session_id].expired():
             del self.sessions[session_id]
 
         del self.clients[sid]

--- a/django/university/socket/sessionsserver.py
+++ b/django/university/socket/sessionsserver.py
@@ -17,7 +17,7 @@ class SessionsServer:
     
     def generate_room_id(self):
         while True:
-            room_id = randbytes(2).hex().upper()
+            room_id = randbytes(4).hex().upper()
             if room_id not in self.rooms:
                 return room_id
     

--- a/django/university/socket/views.py
+++ b/django/university/socket/views.py
@@ -15,6 +15,14 @@ sessions_server = SessionsServer(
     )
 )
 
+async def emit_session_update(sid, session: Session):
+    payload = {
+        'session_id': session.session_id,
+        'session_info': session.to_json(),
+    }
+    
+    await sessions_server.emit_to_session('update_session_info', payload, session.session_id, sid)
+
 @sessions_server.event
 async def connect(sid, environ, auth):
     if auth is None or 'token' not in auth:
@@ -45,12 +53,13 @@ async def connect(sid, environ, auth):
         print(f"Participant {sid} joined session {session_id}")
     
     payload = {
+        'client_id': participant.client_id,
         'session_id': session_id,
         'session_info': session.to_json(),
     }
     
     await sessions_server.emit('connected', payload, to=sid)
-    await sessions_server.emit_to_session('update_session_info', payload, session_id, sid)
+    await emit_session_update(sid, session)
 
 @sessions_server.event
 async def disconnect(sid):
@@ -59,13 +68,20 @@ async def disconnect(sid):
     await sessions_server.leave_session(sid)
     print(f'Client {sid} disconnected')
     
-    payload = {
-        'session_id': session.session_id,
-        'session_info': session.to_json(),
-    }
-    await sessions_server.emit_to_session('update_session_info', payload, session.session_id, sid)
+    await emit_session_update(sid, session)
 
 # TODO: Remove this
 @sessions_server.event
-async def ping(sid, session_id, data):
+async def ping(sid, data):
+    user_session = cast(Session, sessions_server.get_client_session(sid))
+    session_id = user_session.session_id
+    
     await sessions_server.emit_to_session('ping', data, session_id=session_id, sid=sid)
+    
+@sessions_server.event
+async def update_participant(sid, updated_participant):
+    user_session = cast(Session, sessions_server.get_client_session(sid))
+    participant = user_session.participants[sid]
+    participant.update_from_json(updated_participant)
+    
+    await emit_session_update(sid, user_session)

--- a/django/university/socket/views.py
+++ b/django/university/socket/views.py
@@ -50,15 +50,22 @@ async def connect(sid, environ, auth):
     }
     
     await sessions_server.emit('connected', payload, to=sid)
-
+    await sessions_server.emit_to_session('update_session_info', payload, session_id, sid)
 
 @sessions_server.event
 async def disconnect(sid):
+    session = cast(Session, sessions_server.get_client_session(sid))
+    
     await sessions_server.leave_session(sid)
     print(f'Client {sid} disconnected')
+    
+    payload = {
+        'session_id': session.session_id,
+        'session_info': session.to_json(),
+    }
+    await sessions_server.emit_to_session('update_session_info', payload, session.session_id, sid)
 
 # TODO: Remove this
 @sessions_server.event
 async def ping(sid, session_id, data):
-    await sessions_server.emit('ping', data, session_id=session_id)
-    
+    await sessions_server.emit_to_session('ping', data, session_id=session_id, sid=sid)

--- a/django/university/socket/views.py
+++ b/django/university/socket/views.py
@@ -1,33 +1,51 @@
 import os
 import socketio
+from urllib.parse import parse_qs
 
 from university.socket.sessionsserver import SessionsServer
 
 async_mode = None
 
 basedir = os.path.dirname(os.path.realpath(__file__))
-sio = socketio.AsyncServer(
-    async_mode='asgi',
-    cors_allowed_origins="*",
+
+sessions_server = SessionsServer(
+    socketio.AsyncServer(
+        async_mode='asgi',
+        cors_allowed_origins="*",
+    )
 )
 
-session_server = SessionsServer(sio)
-        
-@session_server.event
+@sessions_server.event
 async def connect(sid, environ, auth):
     if auth is None or 'token' not in auth:
         raise ConnectionRefusedError('Authentication failed: No token provided')
-    elif not session_server.valid_token(auth['token']):
+    if not sessions_server.valid_token(auth['token']):
         raise ConnectionRefusedError('Authentication failed: Invalid token')
+    
+    print('Client connected')
+    
+    query_params = parse_qs(environ.get("QUERY_STRING", ""))
+    room_id = query_params.get('room_id', None)
+    room_id = room_id[0] if room_id else None
+    
+    if room_id is None:
+        await sessions_server.create_room(sid)
+    
+        room_id = sessions_server.get_client_room(sid)
+        print(f"Room created: {room_id}")
     else:
-        print('Client connected')
-        await sio.emit('my_response', {'data': 'Connected', 'count': 0}, room=sid)
+        await sessions_server.enter_room(sid, room_id)
+        print(f"Client {sid} joined room {room_id}")
+    
+    await sessions_server.emit('connected', { 'room' : room_id }, to=sid)
 
 
-@session_server.event
-def disconnect(sid):
+@sessions_server.event
+async def disconnect(sid):
+    await sessions_server.leave_room(sid)
     print('Client disconnected')
     
-@session_server.event
+@sessions_server.event
 async def test(sid, environ):
-    await sio.emit('response', 'ya')
+    await sessions_server.sio.disconnect(sid)
+    

--- a/django/university/socket/views.py
+++ b/django/university/socket/views.py
@@ -37,7 +37,7 @@ async def connect(sid, environ, auth):
         await sessions_server.enter_room(sid, room_id)
         print(f"Client {sid} joined room {room_id}")
     
-    await sessions_server.emit('connected', { 'room' : room_id }, to=sid)
+    await sessions_server.emit('connected', { 'room_id' : room_id }, to=sid)
 
 
 @sessions_server.event

--- a/django/university/socket/views.py
+++ b/django/university/socket/views.py
@@ -4,10 +4,6 @@ from urllib.parse import parse_qs
 
 from university.socket.sessionsserver import SessionsServer
 
-async_mode = None
-
-basedir = os.path.dirname(os.path.realpath(__file__))
-
 sessions_server = SessionsServer(
     socketio.AsyncServer(
         async_mode='asgi',
@@ -25,24 +21,24 @@ async def connect(sid, environ, auth):
     print('Client connected')
     
     query_params = parse_qs(environ.get("QUERY_STRING", ""))
-    room_id = query_params.get('room_id', None)
-    room_id = room_id[0] if room_id else None
+    session_id = query_params.get('session_id', None)
+    session_id = session_id[0] if session_id else None
     
-    if room_id is None:
-        await sessions_server.create_room(sid)
+    if session_id is None:
+        await sessions_server.create_session(sid)
     
-        room_id = sessions_server.get_client_room(sid)
-        print(f"Room created: {room_id}")
+        session_id = sessions_server.get_client_session(sid)
+        print(f"Session created: {session_id}")
     else:
-        await sessions_server.enter_room(sid, room_id)
-        print(f"Client {sid} joined room {room_id}")
+        await sessions_server.enter_session(sid, session_id)
+        print(f"Client {sid} joined session {session_id}")
     
-    await sessions_server.emit('connected', { 'room_id' : room_id }, to=sid)
+    await sessions_server.emit('connected', { 'session_id' : session_id }, to=sid)
 
 
 @sessions_server.event
 async def disconnect(sid):
-    await sessions_server.leave_room(sid)
+    await sessions_server.leave_session(sid)
     print('Client disconnected')
 
 # TODO: Remove this
@@ -50,5 +46,5 @@ async def disconnect(sid):
 async def ping(sid, data):
     await sessions_server.emit('ping', {
         'id': data[0]['id'],    
-    }, room=data[0]['room_id'])
+    }, session_id=data[0]['session_id'])
     

--- a/django/university/socket/views.py
+++ b/django/university/socket/views.py
@@ -44,8 +44,11 @@ async def connect(sid, environ, auth):
 async def disconnect(sid):
     await sessions_server.leave_room(sid)
     print('Client disconnected')
-    
+
+# TODO: Remove this
 @sessions_server.event
-async def test(sid, environ):
-    await sessions_server.sio.disconnect(sid)
+async def ping(sid, data):
+    await sessions_server.emit('ping', {
+        'id': data[0]['id'],    
+    }, room=data[0]['room_id'])
     

--- a/django/university/socket/views.py
+++ b/django/university/socket/views.py
@@ -2,6 +2,7 @@ import os
 import socketio
 from urllib.parse import parse_qs
 
+from socketio.exceptions import ConnectionRefusedError
 from university.socket.sessionsserver import SessionsServer
 
 sessions_server = SessionsServer(

--- a/django/university/socket/views.py
+++ b/django/university/socket/views.py
@@ -51,8 +51,6 @@ async def disconnect(sid):
 
 # TODO: Remove this
 @sessions_server.event
-async def ping(sid, data):
-    await sessions_server.emit('ping', {
-        'id': data[0]['id'],    
-    }, session_id=data[0]['session_id'])
+async def ping(sid, session_id, data):
+    await sessions_server.emit('ping', data, session_id=session_id)
     

--- a/django/university/views.py
+++ b/django/university/views.py
@@ -153,7 +153,6 @@ def student_data(request, codigo):
 """
 @api_view(['GET'])
 def get_course_unit_hashes(request):
-
     ids_param = request.query_params.get('ids', '')
 
     try:


### PR DESCRIPTION
This pull request is closely related to [frontend pull request #356](https://github.com/NIAEFEUP/tts-fe/pull/356).

## Features

- Supports multiple collaboration sessions using SocketIO rooms, they are saved in the database and can be accessed again if they haven't expired
- One user creates the session and can then share the access link with others
- Usernames are taken from authenticated users, or, as a fallback, randomly generated with an AdjectiveAnimal combination (but can be changed later)
- Username information is shared in the session as an example of real-time updates
- For testing purposes, ping messages are broadcast in the room (can be seen in browser console)

##### closes #119 :)