### PR TITLE
fix: prod oidc callback invalid url

### DIFF
--- a/django/tts_be/settings.py
+++ b/django/tts_be/settings.py
@@ -109,13 +109,13 @@ OIDC_RP_CLIENT_ID = os.environ['OIDC_RP_CLIENT_ID']
 OIDC_RP_CLIENT_SECRET = os.environ['OIDC_RP_CLIENT_SECRET']
 OIDC_RP_SIGN_ALGO = "RS256"
 
-OIDC_STORE_ID_TOKEN = True
-OIDC_STORE_ACCESS_TOKEN = True
+OIDC_AUTHENTICATION_CALLBACK_URL = "api_oidc_authentication_callback"
 
 OIDC_OP_AUTHORIZATION_ENDPOINT = "https://open-id.up.pt/realms/sigarra/protocol/openid-connect/auth"
 OIDC_OP_TOKEN_ENDPOINT = "https://open-id.up.pt/realms/sigarra/protocol/openid-connect/token"
 OIDC_OP_USER_ENDPOINT = "https://open-id.up.pt/realms/sigarra/protocol/openid-connect/userinfo"
 OIDC_OP_JWKS_ENDPOINT = "https://open-id.up.pt/realms/sigarra/protocol/openid-connect/certs"
+
 OIDC_OP_LOGOUT_ENDPOINT = "https://open-id.up.pt/realms/sigarra/protocol/openid-connect/logout"
 
 OIDC_RP_SCOPES = "openid email profile uporto_data"

--- a/django/university/routes/auth/Csrf.py
+++ b/django/university/routes/auth/Csrf.py
@@ -6,8 +6,6 @@ class Csrf(View):
     def get(self, request):
         response = HttpResponse()
 
-        print("csrf request cookies is: ", request.COOKIES)
-
         if("csrftoken" not in request.COOKIES):
             cookies = request.COOKIES
             response.COOKIES = cookies

--- a/django/university/urls.py
+++ b/django/university/urls.py
@@ -44,4 +44,5 @@ urlpatterns = [
     path('professors/<int:slot>/', views.professor),
     path('course_unit/hash', views.get_course_unit_hashes),
     path('oidc-auth/', include('mozilla_django_oidc.urls')),
+    path('api/oidc-auth/callback/', oidc_views.OIDCAuthenticationCallbackView.as_view(), name="api_oidc_authentication_callback")
 ]

--- a/django/university/views.py
+++ b/django/university/views.py
@@ -83,8 +83,6 @@ def course_units(request, course_id, year, semester):
 
     return JsonResponse(json_data, safe=False)
 
-
-
 """
     Returns the classes of a course unit.
 """

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -12,17 +12,6 @@ http {
     ssl_certificate_key /etc/nginx/certs/server.key;
     server_name tts-dev.niaefeup.pt;
 
-    location /oidc-auth/ {
-      rewrite ^/oidc-auth/(.*)$ /api/oidc-auth/$1 last;
-
-	    proxy_pass http://tts_django:8000/;
-	
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
     location /api/ {
       rewrite ^/api/(.*)$ /$1 break;	
 


### PR DESCRIPTION
Currently, in the federated authentication deployed at tts-staging.niaefeup.pt, after a successful login it is redirecting to `/oidc-auth/callback`. 

However, it needs to be `/api/oidc-auth/callback`. This PR fixes it.

It also removes a temporary solution in the local nginx because now we don't need to redirect `/oidc-auth/callback` to `/api/oidc-auth/callback`. **This has nothing to do with the production deployment**, since the only thing that will be deployed to niployments is the django docker image, nothing else.