### PR TITLE
fix: schedule api broken date

### DIFF
--- a/django/university/controllers/SigarraController.py
+++ b/django/university/controllers/SigarraController.py
@@ -23,15 +23,15 @@ class SigarraController:
     def semester_weeks(self):
         currdate = date.today()
         year = str(currdate.year)
-        first_semester = currdate.month >= 9 and currdate.month <= 12
+        first_semester = currdate.month >= 10 or currdate.month <= 1
         if first_semester: 
-            semana_ini = "1001"
-            semana_fim = "1231"
+            semana_ini = "20241001"
+            semana_fim = "20250131"
         else:
-            semana_ini = "0210"
-            semana_fim = "0601"
+            semana_ini = year + "0210"
+            semana_fim = year + "0601"
         
-        return (year + semana_ini, year + semana_fim)
+        return (semana_ini, semana_fim)
     
     def student_schedule_url(self, nmec, semana_ini, semana_fim) -> str:
         return f"https://sigarra.up.pt/feup/pt/mob_hor_geral.estudante?pv_codigo={nmec}&pv_semana_ini={semana_ini}&pv_semana_fim={semana_fim}" 

--- a/django/university/exchange/utils.py
+++ b/django/university/exchange/utils.py
@@ -26,14 +26,11 @@ def create_marketplace_exchange_on_db(exchanges, curr_student):
    
 
 def build_marketplace_submission_schedule(schedule, submission, auth_student):
-    print("Current auth student: ", auth_student)
     for exchange in submission:
         course_unit = exchange["courseUnitId"]
         class_auth_student_goes_to = exchange["classNameRequesterGoesTo"]
         class_auth_student_goes_from = exchange["classNameRequesterGoesFrom"]
 
-        print("schedule is: ", schedule[auth_student])
-        
         auth_user_valid = (class_auth_student_goes_from, course_unit) in schedule[auth_student]
         if not(auth_user_valid):
             return (ExchangeStatus.STUDENTS_NOT_ENROLLED, None)

--- a/django/university/routes/MarketplaceExchangeView.py
+++ b/django/university/routes/MarketplaceExchangeView.py
@@ -103,7 +103,6 @@ class MarketplaceExchangeView(APIView):
         exchanges = request.POST.getlist('exchangeChoices[]')
         exchanges = list(map(lambda exchange : json.loads(exchange), exchanges))
 
-        print("Marketplace exchange: ", exchanges)
         curr_student = request.user.username
         sigarra_res = SigarraController().get_student_schedule(curr_student)
         

--- a/django/university/routes/auth/InfoView.py
+++ b/django/university/routes/auth/InfoView.py
@@ -21,7 +21,6 @@ class InfoView(View):
                     request.user.username
                 )
 
-
             eligible_exchange = bool(eligible_course_units)
 
             return JsonResponse({

--- a/django/university/routes/student/exchange/StudentSentExchangesView.py
+++ b/django/university/routes/student/exchange/StudentSentExchangesView.py
@@ -49,9 +49,6 @@ class StudentSentExchangesView(APIView):
         paginator = Paginator(exchanges, 10)
         page_obj = paginator.get_page(page_number if page_number != None else 1)
 
-        for exchange in page_obj:
-            print(type(exchange) == MarketplaceExchange)
-
         return {
             "page": {
                 "current": page_obj.number,

--- a/django/university/routes/student/schedule/StudentScheduleView.py
+++ b/django/university/routes/student/schedule/StudentScheduleView.py
@@ -20,6 +20,7 @@ class StudentScheduleView(APIView):
                 return HttpResponse(status=sigarra_res.status_code)
 
             schedule_data = sigarra_res.data
+
             old_schedule = hashlib.sha256(json.dumps(schedule_data, sort_keys=True).encode()).hexdigest()
 
             update_schedule_accepted_exchanges(request.user.username, schedule_data)


### PR DESCRIPTION
The year change from 2024 to 2025 broke the logic of creating the `semana_ini` and `semana_fim`.

Currently, the first semester is harcoded, but that is ok since we are going to change the url endpoint we will be fetching the schedule from. 