### PR TITLE
fix: added unique constraint that was missing to class id

### DIFF
--- a/postgres/sql/00_schema_postgres.sql
+++ b/postgres/sql/00_schema_postgres.sql
@@ -24,12 +24,11 @@ SET row_security = off;
 --
 
 CREATE TABLE "public"."class" (
-    "id" bigint NOT NULL,
+    "id" bigint NOT NULL UNIQUE,
     "name" character varying(31) NOT NULL,
     "course_unit_id" integer NOT NULL,
     "last_updated" timestamp with time zone NOT NULL
 );
-
 
 --
 -- TOC entry 223 (class 1259 OID 16797)


### PR DESCRIPTION
Because of the `user course units` table, it was complaning that the `id` constraint class was not unique. 

In fact it was not, but since the id of a class can be unique, this fixes the error when running the backend after cleaning the data or for the first time by adding the `UNIQUE` constraint to the `class` table