### PR TITLE
feature: automatic student class fill

### DIFF
--- a/django/university/controllers/StudentController.py
+++ b/django/university/controllers/StudentController.py
@@ -12,6 +12,15 @@ class StudentController:
     """
 
     @staticmethod
+    def student_class(nmec, course_unit_id):
+        potential_user_class = UserCourseUnits.objects.filter(user_nmec=nmec, course_unit_id__id=course_unit_id)
+
+        if potential_user_class.exists():
+            return potential_user_class.first().class_field
+        else:
+            return None
+
+    @staticmethod
     def populate_user_course_unit_data(nmec: int, erase_previous: bool = False):
         if(erase_previous):
             UserCourseUnits.objects.filter(user_nmec=nmec).delete()

--- a/django/university/routes/exchange/card/metadata/ExchangeCardMetadataView.py
+++ b/django/university/routes/exchange/card/metadata/ExchangeCardMetadataView.py
@@ -2,11 +2,12 @@ import requests
 
 from rest_framework.views import APIView
 from django.http import HttpResponse, JsonResponse
-from django.db.models import Prefetch
 
+from university.serializers.ClassSerializer import ClassSerializer
+
+from university.controllers.StudentController import StudentController
 from university.controllers.ClassController import ClassController
 from university.controllers.SigarraController import SigarraController
-from university.models import Class
 
 class ExchangeCardMetadataView(APIView):
     def get(self, request, course_unit_id):
@@ -19,9 +20,19 @@ class ExchangeCardMetadataView(APIView):
                 return HttpResponse(status=sigarra_res.status_code)
 
             students = sigarra_res.data
+
             new_response = JsonResponse({
                 "classes": list(ClassController.get_classes(course_unit_id)),
-                "students": students
+                "students": [
+                    {
+                        "codigo": student.get("codigo"),
+                        "nome": student.get("nome"),
+                        "classInfo": 
+                            ClassSerializer(StudentController.student_class(student.get("codigo"), course_unit_id)).data 
+                            if ClassSerializer(StudentController.student_class(student.get("codigo"), course_unit_id)).data.get("name") != ""
+                            else None
+                    } for student in students
+                ]
             }, safe=False)
 
             new_response.status_code = sigarra_res.status_code

--- a/django/university/routes/student/schedule/StudentScheduleView.py
+++ b/django/university/routes/student/schedule/StudentScheduleView.py
@@ -45,7 +45,6 @@ class StudentScheduleView(APIView):
 
         schedule_data = sigarra_res.data
 
-        # print("SCHEDULE_DATA BEFORE retrieve course unit classes: ", schedule_data)
         update_schedule_accepted_exchanges(username, schedule_data)
 
         course_unit_classes = set()

--- a/django/university/serializers/ClassSerializer.py
+++ b/django/university/serializers/ClassSerializer.py
@@ -1,0 +1,5 @@
+from rest_framework import serializers
+
+class ClassSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=31)
+    last_updated = serializers.DateTimeField()


### PR DESCRIPTION
In the backend, we put the name of the class of the student in the response. It is unfeasible to go on about fetching the classes of each user of the all of the possible students to select from when the user is choosing between requests.