### PR TITLE
fix: if user has already accepted direct exchange the backend does not crash

### DIFF
--- a/django/university/controllers/ExchangeController.py
+++ b/django/university/controllers/ExchangeController.py
@@ -23,6 +23,7 @@ class ExchangeType(Enum):
 class DirectExchangePendingMotive(Enum):
     USER_DID_NOT_ACCEPT = 1
     OTHERS_DID_NOT_ACCEPT = 2
+    NOT_PENDING = 3
     
     @staticmethod
     def get_pending_motive(curr_user_nmec: str, direct_exchange: DirectExchange):
@@ -30,12 +31,15 @@ class DirectExchangePendingMotive(Enum):
             participant_nmec=curr_user_nmec, direct_exchange=direct_exchange).all()
         )
 
+        # The participants list includes the options in the exchange of the current user
         for participant in participants:
             if not participant.accepted:
                 return DirectExchangePendingMotive.USER_DID_NOT_ACCEPT
 
         if not direct_exchange.accepted:
             return DirectExchangePendingMotive.OTHERS_DID_NOT_ACCEPT
+
+        return DirectExchangePendingMotive.NOT_PENDING 
     
     @staticmethod
     def get_value(pending_motive):

--- a/django/university/routes/student/exchange/StudentReceivedExchangesView.py
+++ b/django/university/routes/student/exchange/StudentReceivedExchangesView.py
@@ -1,13 +1,11 @@
 from django.core.paginator import Paginator
-from django.http.response import HttpResponse, JsonResponse
+from django.http.response import JsonResponse
 from rest_framework.views import APIView
 from django.db.models import Prefetch
 
 from university.controllers.ExchangeController import DirectExchangePendingMotive
-from university.controllers.SigarraController import SigarraController
 from university.models import DirectExchange, DirectExchangeParticipants
 from university.serializers.DirectExchangeParticipantsSerializer import DirectExchangeParticipantsSerializer
-from university.serializers.MarketplaceExchangeClassSerializer import MarketplaceExchangeClassSerializer
 
 class StudentReceivedExchangesView(APIView):
     def get(self, request):


### PR DESCRIPTION
If the exchange was accepted, the pending motive as being `None` and that was crashing the backend.