### PR TITLE
feat: admins can mark requests as awaiting for information

### DIFF
--- a/django/university/controllers/AdminRequestFiltersController.py
+++ b/django/university/controllers/AdminRequestFiltersController.py
@@ -4,5 +4,5 @@ class AdminRequestFiltersController:
         return [
             "activeCourse",
             "activeCurricularYear",
-            "activeState"
+            "activeStates"
         ] 

--- a/django/university/routes/course_unit/CourseUnitEnrollmentView.py
+++ b/django/university/routes/course_unit/CourseUnitEnrollmentView.py
@@ -17,7 +17,7 @@ class CourseUnitEnrollmentView(APIView):
         self.filter_actions = {
             "activeCourse": self.filter_active_course,
             "activeCurricularYear": self.filter_active_curricular_year,
-            "activeState": self.filter_active_state
+            "activeStates": self.filter_active_state
         }
 
     def filter_active_course(self, exchanges, major_id):
@@ -43,9 +43,10 @@ class CourseUnitEnrollmentView(APIView):
         )
 
     def filter_active_state(self, exchanges, state):
+        states = state.split(",")
         return list(
             filter(
-                lambda exchange: exchange.get("admin_state") == state,
+                lambda exchange: exchange.get("admin_state") in states,
                 exchanges
             )
         )

--- a/django/university/routes/exchange/AdminExchangeRequestMarkAwaitingInformationView.py
+++ b/django/university/routes/exchange/AdminExchangeRequestMarkAwaitingInformationView.py
@@ -1,0 +1,10 @@
+from django.http import HttpResponse 
+from django.views import View
+
+from university.controllers.AdminExchangeStateChangeController import AdminExchangeStateChangeController
+
+class AdminExchangeRequestMarkAwaitingInformationView(View):
+    def put(self, request, request_type, id):
+        AdminExchangeStateChangeController().update_state_to(request_type, id, "awaiting-information")
+    
+        return HttpResponse(status=200)

--- a/django/university/routes/exchange/AdminRequestAwaitingInformationView.py
+++ b/django/university/routes/exchange/AdminRequestAwaitingInformationView.py
@@ -3,7 +3,7 @@ from django.views import View
 
 from university.controllers.AdminExchangeStateChangeController import AdminExchangeStateChangeController
 
-class AdminExchangeRequestMarkAwaitingInformationView(View):
+class AdminRequestAwaitingInformationView(View):
     def put(self, request, request_type, id):
         AdminExchangeStateChangeController().update_state_to(request_type, id, "awaiting-information")
     

--- a/django/university/routes/exchange/DirectExchangeView.py
+++ b/django/university/routes/exchange/DirectExchangeView.py
@@ -28,7 +28,7 @@ class DirectExchangeView(View):
         self.filter_actions = {
             "activeCourse": self.filter_active_course,
             "activeCurricularYear": self.filter_active_curricular_year,
-            "activeState": self.filter_active_state
+            "activeStates": self.filter_active_state
         }
 
     def filter_active_course(self, exchanges, major_id):
@@ -54,9 +54,10 @@ class DirectExchangeView(View):
         )
 
     def filter_active_state(self, exchanges, state):
+        states = state.split(",")
         return list(
             filter(
-                lambda exchange: exchange.get("admin_state") == state,
+                lambda exchange: exchange.get("admin_state") in states,
                 exchanges
             )
         )

--- a/django/university/routes/exchange/ExchangeUrgentView.py
+++ b/django/university/routes/exchange/ExchangeUrgentView.py
@@ -18,7 +18,7 @@ class ExchangeUrgentView(View):
         self.filter_actions = {
             "activeCourse": self.filter_active_course,
             "activeCurricularYear": self.filter_active_curricular_year,
-            "activeState": self.filter_active_state
+            "activeStates": self.filter_active_state
         }
 
     def filter_active_course(self, exchanges, major_id):
@@ -44,9 +44,10 @@ class ExchangeUrgentView(View):
         )
 
     def filter_active_state(self, exchanges, state):
+        states = state.split(",")
         return list(
             filter(
-                lambda exchange: exchange.get("admin_state") == state,
+                lambda exchange: exchange.get("admin_state") in states,
                 exchanges
             )
         )

--- a/django/university/serializers/CourseUnitEnrollmentsSerializer.py
+++ b/django/university/serializers/CourseUnitEnrollmentsSerializer.py
@@ -20,7 +20,6 @@ class CourseUnitEnrollmentsSerializer(serializers.Serializer):
 
 class CourseUnitEnrollmentOptionsSerializer(serializers.Serializer):
     course_unit = serializers.SerializerMethodField()
-    class_user_goes_to = serializers.SerializerMethodField()
 
     def get_course_unit(self, obj):
         course_unit_id = obj.course_unit.id
@@ -28,14 +27,4 @@ class CourseUnitEnrollmentOptionsSerializer(serializers.Serializer):
         try:
             return model_to_dict(CourseUnit.objects.get(pk=course_unit_id))
         except:
-            return None
-
-    def get_class_user_goes_to(self, obj):
-        class_issuer_id = obj.class_field.name
-        classes = ClassController.get_classes(obj.course_unit.id)
-        filtered_classes = list(filter(lambda x: x['name'] == class_issuer_id, classes))
-
-        try:
-            return filtered_classes[0]
-        except: 
             return None

--- a/django/university/urls.py
+++ b/django/university/urls.py
@@ -19,6 +19,7 @@ from university.routes.exchange.verify.ExchangeVerifyView import ExchangeVerifyV
 from university.routes.admin.AdminExchangeCoursesView import AdminExchangeCoursesView
 from university.routes.exchange.ExchangeUrgentView import ExchangeUrgentView
 from university.routes.student.StudentCourseMetadataView import StudentCourseMetadataView
+from university.routes.exchange.AdminExchangeRequestMarkAwaitingInformationView import AdminExchangeRequestMarkAwaitingInformationView
 
 from university.middleware.exchange_admin import exchange_admin_required
 from university.routes.exchange.verify.DirectExchangeValidationView import DirectExchangeValidationView
@@ -63,5 +64,6 @@ urlpatterns = [
     path('exchange/admin/courses/', exchange_admin_required(AdminExchangeCoursesView.as_view())),
     path('exchange/admin/request/<str:request_type>/<int:id>/reject/', exchange_admin_required(AdminExchangeRequestRejectView.as_view())),
     path('exchange/admin/request/<str:request_type>/<int:id>/accept/', exchange_admin_required(AdminExchangeRequestAcceptView.as_view())),
+    path('exchange/admin/request/<str:request_type>/<int:id>/awaiting-information/', exchange_admin_required(AdminExchangeRequestMarkAwaitingInformationView.as_view())),
     path('api/oidc-auth/callback/', oidc_views.OIDCAuthenticationCallbackView.as_view(), name="api_oidc_authentication_callback")
 ]

--- a/django/university/urls.py
+++ b/django/university/urls.py
@@ -19,7 +19,7 @@ from university.routes.exchange.verify.ExchangeVerifyView import ExchangeVerifyV
 from university.routes.admin.AdminExchangeCoursesView import AdminExchangeCoursesView
 from university.routes.exchange.ExchangeUrgentView import ExchangeUrgentView
 from university.routes.student.StudentCourseMetadataView import StudentCourseMetadataView
-from university.routes.exchange.AdminExchangeRequestMarkAwaitingInformationView import AdminExchangeRequestMarkAwaitingInformationView
+from university.routes.exchange.AdminRequestAwaitingInformationView import AdminRequestAwaitingInformationView
 
 from university.middleware.exchange_admin import exchange_admin_required
 from university.routes.exchange.verify.DirectExchangeValidationView import DirectExchangeValidationView
@@ -64,6 +64,6 @@ urlpatterns = [
     path('exchange/admin/courses/', exchange_admin_required(AdminExchangeCoursesView.as_view())),
     path('exchange/admin/request/<str:request_type>/<int:id>/reject/', exchange_admin_required(AdminExchangeRequestRejectView.as_view())),
     path('exchange/admin/request/<str:request_type>/<int:id>/accept/', exchange_admin_required(AdminExchangeRequestAcceptView.as_view())),
-    path('exchange/admin/request/<str:request_type>/<int:id>/awaiting-information/', exchange_admin_required(AdminExchangeRequestMarkAwaitingInformationView.as_view())),
+    path('exchange/admin/request/<str:request_type>/<int:id>/awaiting-information/', exchange_admin_required(AdminRequestAwaitingInformationView.as_view())),
     path('api/oidc-auth/callback/', oidc_views.OIDCAuthenticationCallbackView.as_view(), name="api_oidc_authentication_callback")
 ]


### PR DESCRIPTION
- Admins can now select multiple state filters at the same time
- Admins can now mark request as awaiting for information