### PR TITLE
Enable conflicts with theoretical classes

### DIFF
--- a/django/.env.example
+++ b/django/.env.example
@@ -26,3 +26,6 @@ OIDC_RP_CLIENT_SECRET=
 
 SIGARRA_USERNAME=
 SIGARRA_PASSWORD=
+
+# Specify whether theoretical classes should generate conflicts
+T_CLASS_CONFLICTS=1

--- a/django/university/controllers/ExchangeController.py
+++ b/django/university/controllers/ExchangeController.py
@@ -148,8 +148,8 @@ class ExchangeController:
                 if key == other_key:
                     continue
 
-                (class_schedule_day, class_schedule_start, class_schedule_end) = (class_schedule["dia"], class_schedule["hora_inicio"], class_schedule["aula_duracao"] + class_schedule["hora_inicio"])
-                (overlap_param_day, overlap_param_start, overlap_param_end) = (other_class_schedule["dia"], other_class_schedule["hora_inicio"], other_class_schedule["aula_duracao"] + other_class_schedule["hora_inicio"])
+                (class_schedule_day, class_schedule_start, class_schedule_end) = (class_schedule["dia"], class_schedule["hora_inicio"] / 3600, class_schedule["aula_duracao"] + class_schedule["hora_inicio"] / 3600)
+                (overlap_param_day, overlap_param_start, overlap_param_end) = (other_class_schedule["dia"], other_class_schedule["hora_inicio"] / 3600, other_class_schedule["aula_duracao"] + other_class_schedule["hora_inicio"] / 3600)
 
                 if check_class_schedule_overlap(class_schedule_day, class_schedule_start, class_schedule_end, overlap_param_day, overlap_param_start, overlap_param_end):
                     return True

--- a/django/university/controllers/ExchangeController.py
+++ b/django/university/controllers/ExchangeController.py
@@ -4,7 +4,7 @@ import json
 from django.core.paginator import Paginator
 from university.controllers.ClassController import ClassController
 from university.controllers.SigarraController import SigarraController
-from university.exchange.utils import ExchangeStatus, check_class_schedule_overlap, course_unit_by_id
+from university.exchange.utils import ExchangeStatus, check_class_mandatory, check_class_schedule_overlap, course_unit_by_id
 from university.models import DirectExchange, DirectExchangeParticipants, ExchangeExpirations, MarketplaceExchange
 from django.utils import timezone
 from enum import Enum
@@ -148,10 +148,11 @@ class ExchangeController:
                 if key == other_key:
                     continue
 
-                (class_schedule_day, class_schedule_start, class_schedule_end) = (class_schedule["dia"], class_schedule["hora_inicio"] / 3600, class_schedule["aula_duracao"] + class_schedule["hora_inicio"] / 3600)
-                (overlap_param_day, overlap_param_start, overlap_param_end) = (other_class_schedule["dia"], other_class_schedule["hora_inicio"] / 3600, other_class_schedule["aula_duracao"] + other_class_schedule["hora_inicio"] / 3600)
+                (class_schedule_day, class_schedule_start, class_schedule_end, class_schedule_type) = (class_schedule["dia"], class_schedule["hora_inicio"] / 3600, class_schedule["aula_duracao"] + class_schedule["hora_inicio"] / 3600, class_schedule['tipo'])
+                (overlap_param_day, overlap_param_start, overlap_param_end, overlap_param_type) = (other_class_schedule["dia"], other_class_schedule["hora_inicio"] / 3600, other_class_schedule["aula_duracao"] + other_class_schedule["hora_inicio"] / 3600, other_class_schedule['tipo'])
 
-                if check_class_schedule_overlap(class_schedule_day, class_schedule_start, class_schedule_end, overlap_param_day, overlap_param_start, overlap_param_end):
+                if (check_class_mandatory(class_schedule_type) and check_class_mandatory(overlap_param_type)
+                    and check_class_schedule_overlap(class_schedule_day, class_schedule_start, class_schedule_end, overlap_param_day, overlap_param_start, overlap_param_end)):
                     return True
 
         return False

--- a/django/university/controllers/SigarraController.py
+++ b/django/university/controllers/SigarraController.py
@@ -141,7 +141,7 @@ class SigarraController:
             return SigarraResponse(None, response.status_code)
 
         classes = json.loads(response.content)["horario"]
-        class_schedule = list(filter(lambda c: c["turma_sigla"] == class_name, classes))
+        class_schedule = list(filter(lambda c: any(schedule["turma_sigla"] == class_name for schedule in c["turmas"]), classes))
         theoretical_schedule = list(filter(lambda c: c["tipo"] == "T" and any(schedule["turma_sigla"] == class_name for schedule in c["turmas"]), classes))
         
         return SigarraResponse((class_schedule, theoretical_schedule), 200)

--- a/django/university/exchange/utils.py
+++ b/django/university/exchange/utils.py
@@ -107,14 +107,7 @@ def build_student_schedule_dict(schedule: list):
     }
 
 def check_class_schedule_overlap(day_1: int, start_1: int, end_1: int, day_2: int, start_2: int, end_2: int) -> bool:
-    if day_1 != day_2:
-        return False
-
-    if (start_2 >= start_1 and start_2 <= end_1) or (start_1 >= start_2 and start_1 <= end_2):
-        return True
-
-    return False
-
+    return day_1 == day_2 and start_1 <= end_2 and start_2 <= end_1
 
 def exchange_overlap(student_schedules, username) -> bool:
     for (key, class_schedule) in student_schedules[username].items():
@@ -122,8 +115,8 @@ def exchange_overlap(student_schedules, username) -> bool:
             if key == other_key:
                 continue
 
-            (class_schedule_day, class_schedule_start, class_schedule_end) = (class_schedule["dia"], class_schedule["hora_inicio"], class_schedule["aula_duracao"] + class_schedule["hora_inicio"])
-            (overlap_param_day, overlap_param_start, overlap_param_end) = (other_class_schedule["dia"], other_class_schedule["hora_inicio"], other_class_schedule["aula_duracao"] + other_class_schedule["hora_inicio"])
+            (class_schedule_day, class_schedule_start, class_schedule_end) = (class_schedule["dia"], class_schedule["hora_inicio"] / 3600, class_schedule["aula_duracao"] + class_schedule["hora_inicio"] / 3600)
+            (overlap_param_day, overlap_param_start, overlap_param_end) = (other_class_schedule["dia"], other_class_schedule["hora_inicio"] / 3600, other_class_schedule["aula_duracao"] + other_class_schedule["hora_inicio"] / 3600)
 
             if check_class_schedule_overlap(class_schedule_day, class_schedule_start, class_schedule_end, overlap_param_day, overlap_param_start, overlap_param_end):
                 return True

--- a/django/university/exchange/utils.py
+++ b/django/university/exchange/utils.py
@@ -107,7 +107,7 @@ def build_student_schedule_dict(schedule: list):
     }
 
 def check_class_schedule_overlap(day_1: int, start_1: int, end_1: int, day_2: int, start_2: int, end_2: int) -> bool:
-    return day_1 == day_2 and start_1 <= end_2 and start_2 <= end_1
+    return day_1 == day_2 and start_1 < end_2 and start_2 < end_1
 
 def exchange_overlap(student_schedules, username) -> bool:
     for (key, class_schedule) in student_schedules[username].items():

--- a/django/university/exchange/utils.py
+++ b/django/university/exchange/utils.py
@@ -187,7 +187,7 @@ def convert_sigarra_schedule(schedule_data):
                     'id': schedule['ocorrencia_id'],
                     'lesson_type': schedule["tipo"],
                     'day': schedule['dia'] - 2,
-                    'start_time': str(schedule['hora_inicio'] / 3600),
+                    'start_time': schedule['hora_inicio'] / 3600,
                     'duration': schedule['aula_duracao'],
                     'location': schedule['sala_sigla'],
                     'professors_link': '',

--- a/django/university/routes/MarketplaceExchangeView.py
+++ b/django/university/routes/MarketplaceExchangeView.py
@@ -169,7 +169,6 @@ class MarketplaceExchangeView(APIView):
     def insert_marketplace_exchange(self, exchanges, user):
         issuer_name = f"{user.first_name} {user.last_name.split(' ')[-1]}"
         marketplace_exchange = MarketplaceExchange.objects.create(
-            id=MarketplaceExchange.objects.latest("id").id + 1,
             issuer_name=issuer_name,
             issuer_nmec=user.username, 
             accepted=False
@@ -178,7 +177,6 @@ class MarketplaceExchangeView(APIView):
             course_unit_id = int(exchange["courseUnitId"])
             course_unit = CourseUnit.objects.get(pk=course_unit_id)
             MarketplaceExchangeClass.objects.create(
-                id=MarketplaceExchangeClass.objects.latest("id").id + 1,
                 marketplace_exchange=marketplace_exchange,
                 course_unit_acronym=course_unit.acronym,
                 course_unit_id=course_unit_id,


### PR DESCRIPTION
Closes #155 

This PR also solves some bugs that we had with the class overlap logic. To test this, do not forget to set the `T_CLASS_CONFLICTS` boolean in `django/.env.dev`