### PR TITLE
fix: schedule loading is not slow anymore to the point of visual glitches

### DIFF
--- a/django/university/routes/MarketplaceExchangeView.py
+++ b/django/university/routes/MarketplaceExchangeView.py
@@ -1,6 +1,8 @@
 import json
 import hashlib
 
+from django.utils import timezone
+
 from rest_framework.views import APIView
 from django.core.paginator import Paginator
 from django.http import HttpResponse, JsonResponse
@@ -185,7 +187,8 @@ class MarketplaceExchangeView(APIView):
             issuer_nmec=user.username, 
             accepted=False,
             hash=exchange_hash,
-            canceled=False
+            canceled=False,
+            date=timezone.now()
         )
         for exchange in exchanges:
             course_unit_id = int(exchange["courseUnitId"])

--- a/django/university/routes/student/schedule/StudentScheduleView.py
+++ b/django/university/routes/student/schedule/StudentScheduleView.py
@@ -37,14 +37,15 @@ class StudentScheduleView(APIView):
             new_response.status_code = sigarra_res.status_code
 
             if(nmec == ""):
-                StudentController.populate_course_metadata(
-                    request.user.username,
-                    erase_previous=len(StudentCourseMetadata.objects.filter(nmec = request.user.username)) > 0
-                )
-                StudentController.populate_user_course_unit_data(
-                    request.user.username, 
-                    erase_previous=len(UserCourseUnits.objects.filter(user_nmec = request.user.username)) > 0
-                ) 
+                if len(StudentCourseMetadata.objects.filter(nmec = request.user.username)) == 0:
+                    StudentController.populate_course_metadata(
+                        request.user.username,
+                    )
+
+                if len(UserCourseUnits.objects.filter(user_nmec = request.user.username)) == 0:
+                    StudentController.populate_user_course_unit_data(
+                        request.user.username, 
+                    ) 
 
             return new_response 
         


### PR DESCRIPTION
Always populating student course units and student course metadata was slowing down the schedule endpoint thus making visual glitches due to the delay of responding to appear

StudentCourseUnits will be updated in the actions that need to update them, such as accepting a direct exchange instead of always.