### PR TITLE
Request substitution confirmation pop-up

### DIFF
--- a/django/university/routes/MarketplaceExchangeView.py
+++ b/django/university/routes/MarketplaceExchangeView.py
@@ -147,11 +147,11 @@ class MarketplaceExchangeView(APIView):
             if ExchangeController.exchange_overlap(student_schedules, curr_student):
                 return JsonResponse({"error": "classes-overlap"}, status=400, safe=False)
 
-        # By specifying replace=true, the user can replace a request with the same hash with a new one
         replace = request.POST.get('replace', 'false') == 'true'
-        if not replace:
-            exchange_hash = ExchangeHasher.hash(exchanges, username=curr_student)
+        exchange_hash = ExchangeHasher.hash(exchanges, username=curr_student)
 
+        # Unless replace=true, we want to avoid creating duplicate requests
+        if not replace:
             if MarketplaceExchange.objects.filter(hash=exchange_hash, canceled=False).exists():
                 return JsonResponse({"error": "duplicate-request"}, status=400, safe=False)
 

--- a/django/university/routes/MarketplaceExchangeView.py
+++ b/django/university/routes/MarketplaceExchangeView.py
@@ -229,6 +229,8 @@ class MarketplaceExchangeView(APIView):
                     class_issuer_goes_to=exchange["classNameRequesterGoesTo"]
                 )
 
+        return JsonResponse({"success": True}, safe=False)
+
     def cancel_old_marketplace_exchanges(self, user, exchange_hash):
         with transaction.atomic():
             old_exchanges = MarketplaceExchange.objects.filter(

--- a/django/university/routes/MarketplaceExchangeView.py
+++ b/django/university/routes/MarketplaceExchangeView.py
@@ -199,11 +199,7 @@ class MarketplaceExchangeView(APIView):
                 old_request.save()
 
     def add_normal_marketplace_exchange(self, request, exchanges, exchange_hash, replace_existing=False):
-        self.insert_marketplace_exchange(exchanges, request.user, exchange_hash, replace_existing)
-
-        return JsonResponse({"success": True}, safe=False)
-
-    def insert_marketplace_exchange(self, exchanges, user, exchange_hash, replace_existing=False):
+        user = request.user
         issuer_name = f"{user.first_name} {user.last_name.split(' ')[-1]}"
 
         with transaction.atomic():

--- a/django/university/routes/MarketplaceExchangeView.py
+++ b/django/university/routes/MarketplaceExchangeView.py
@@ -156,7 +156,7 @@ class MarketplaceExchangeView(APIView):
             if not is_urgent and MarketplaceExchange.objects.filter(hash=exchange_hash, canceled=False).exists():
                 return JsonResponse({"error": "duplicate-request"}, status=400, safe=False)
 
-            if is_urgent and ExchangeUrgentRequests.objects.filter(hash=exchange_hash).exists():
+            if is_urgent and ExchangeUrgentRequests.objects.filter(hash=exchange_hash, admin_state="untreated").exists():
                 return JsonResponse({"error": "duplicate-request"}, status=400, safe=False)
 
         if is_urgent:

--- a/django/university/routes/exchange/DirectExchangeView.py
+++ b/django/university/routes/exchange/DirectExchangeView.py
@@ -134,7 +134,7 @@ class DirectExchangeView(View):
         with transaction.atomic():
             if replace:
                 # Cancel previous exchanges with same hash
-                previous_exchanges = DirectExchange.objects.filter(hash=exchange_hash, accepted=False, canceled=False)
+                previous_exchanges = DirectExchange.objects.filter(hash=exchange_hash, canceled=False)
                 for previous_exchange in previous_exchanges:
                     ExchangeValidationController().cancel_exchange(previous_exchange)
 


### PR DESCRIPTION
# Description

Backend support for the frontend PR [#596](https://github.com/NIAEFEUP/tts-fe/pull/596). Modifies the exchange request routes to accept the attribute `replace`, which, when set to true, allows the server to cancel a previous request with the same hash as the new, preventing the new insertion from failing.

> [!IMPORTANT]
> When testing this branch, don't forget to also checkout the frontend to the branch [`feature/confirmation-popup`](https://github.com/NIAEFEUP/tts-fe/tree/feature/confirmation-popup)

# Changes Made

- Changed `MarketplaceExchangeView` and `DirectExchangeView`, to accept the `replace` attribute on the POST method, not verifying hash collisions when set to true, and, instead, cancelling/rejecting the old request
- Separate hash collision checking between normal and urgent marketplace requests (currently, when a request is submitted, its hash is checked against the hashes of both normal and urgent requests, independently of its type)