### PR TITLE
fix: first semester not loading in dev

### DIFF
--- a/django/university/controllers/ClassController.py
+++ b/django/university/controllers/ClassController.py
@@ -144,7 +144,7 @@ class ClassController:
             slot = Slot(
                 id=entry.get('aula_id'),
                 lesson_type=entry.get('tipo'),
-                day=ScheduleController.from_sigarra_day(entry.get('dia')),
+                day=ScheduleController.from_sigarra_day(entry.get('dia'), 0),
                 start_time=float(entry.get('hora_inicio', 0)) / 3600.0,
                 duration=float(entry.get('aula_duracao', 0)),
                 location=entry.get('sala_sigla'),

--- a/django/university/controllers/SigarraController.py
+++ b/django/university/controllers/SigarraController.py
@@ -32,7 +32,7 @@ class SigarraController:
         year = str(currdate.year)
         first_semester = int(CONFIG["EXCHANGE_SEMESTER"]) == 1 if CONFIG["EXCHANGE_SEMESTER"] else currdate.month >= 10 or currdate.month <= 1
         if first_semester:
-            if currdate.month == 1:
+            if currdate.month <= 2:
                 year = str(int(year) - 1)
 
             semana_ini = year + "1001"

--- a/django/university/routes/exchange/DirectExchangeView.py
+++ b/django/university/routes/exchange/DirectExchangeView.py
@@ -253,7 +253,6 @@ class DirectExchangeView(View):
             # Revert participant acceptance, to allow to retry in case of an error
             self.set_participant_acceptance(exchange, request.user.username, False)
 
-            print("ERROR: ", e)
             return JsonResponse({"success": False}, status=400, safe=False)
 
     def set_participant_acceptance(self, exchange, nmec: str, accepted: bool):


### PR DESCRIPTION
The problem is that in february, even when we try to force semester 1 (since at  this point none of us have schedules), we are unable to test the exchange system with real schedules