### PR TITLE
feat: add Sentry error tracking to backend

### DIFF
--- a/django/.env.example
+++ b/django/.env.example
@@ -38,3 +38,8 @@ EXCHANGE_SEMESTER=1
 
 # Specify whether theoretical classes should generate conflicts
 T_CLASS_CONFLICTS=1
+
+# Sentry (optional - leave empty to disable error tracking)
+SENTRY_DSN=
+SENTRY_TRACES_SAMPLE_RATE=0.2
+SENTRY_PROFILE_SAMPLE_RATE=0.2

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -16,3 +16,4 @@ daphne==4.1.2
 python-socketio==5.14.0
 django_anymail==12.0
 django-ratelimit==4.1.0
+sentry-sdk[django]>=2.25.0

--- a/django/tts_be/settings.py
+++ b/django/tts_be/settings.py
@@ -11,16 +11,28 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 """
 
 from pathlib import Path
-import os 
+import os
 from dotenv import dotenv_values
 from django.core import mail
 
 import logging.config
+import sentry_sdk
 
 CONFIG={
     **dotenv_values(".env"),  # load variables
     **os.environ,  # override loaded values with environment variables
 }
+
+SENTRY_DSN = CONFIG.get("SENTRY_DSN")
+if SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        send_default_pii=True,
+        enable_logs=True,
+        traces_sample_rate=float(CONFIG.get("SENTRY_TRACES_SAMPLE_RATE", 1.0)),
+        profile_session_sample_rate=float(CONFIG.get("SENTRY_PROFILE_SAMPLE_RATE", 1.0)),
+        profile_lifecycle="trace",
+    )
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/django/tts_be/urls.py
+++ b/django/tts_be/urls.py
@@ -16,7 +16,13 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
-urlpatterns = [ 
-    path('admin/', admin.site.urls), 
+
+def trigger_error(request):
+    1 / 0
+
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+    path('sentry-debug/', trigger_error),
     path('', include('university.urls')),
 ]

--- a/django/tts_be/urls.py
+++ b/django/tts_be/urls.py
@@ -16,11 +16,6 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
-
-def trigger_error(request):
-    1 / 0
-
-
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('sentry-debug/', trigger_error),

--- a/django/tts_be/urls.py
+++ b/django/tts_be/urls.py
@@ -18,6 +18,5 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('sentry-debug/', trigger_error),
     path('', include('university.urls')),
 ]


### PR DESCRIPTION
Closes #283

## What

Integrates Sentry into the Django backend for error tracking and performance monitoring.

## To enable

Still need to set `SENTRY_DSN` in our production environment.