### PR TITLE
Feature/reinit colaborative sessions

### DIFF
--- a/django/tts_be/asgi.py
+++ b/django/tts_be/asgi.py
@@ -15,4 +15,5 @@ from university.socket.views import sessions_server
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tts_be.settings')
 
-application = socketio.ASGIApp(sessions_server.sio, get_asgi_application())
+django_app = socketio.ASGIApp(sessions_server.sio, get_asgi_application())
+application = socketio.ASGIApp(sessions_server.sio, django_app)

--- a/django/tts_be/asgi.py
+++ b/django/tts_be/asgi.py
@@ -15,5 +15,5 @@ from university.socket.views import sessions_server
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tts_be.settings')
 
-django_app = socketio.ASGIApp(sessions_server.sio, get_asgi_application())
+django_app = get_asgi_application()
 application = socketio.ASGIApp(sessions_server.sio, django_app)

--- a/django/tts_be/settings.py
+++ b/django/tts_be/settings.py
@@ -95,7 +95,7 @@ if not DEBUG:
 INSTALLED_APPS = [
     'corsheaders',
     'anymail',
-    # 'daphne',
+    'daphne',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -106,7 +106,7 @@ INSTALLED_APPS = [
     'mozilla_django_oidc',
     'university',
     'exchange',
-    # 'channels',
+    'channels',
 ]
 
 EMAIL_HOST = os.getenv("EMAIL_HOST", "tts-mailpit")

--- a/django/tts_be/settings.py
+++ b/django/tts_be/settings.py
@@ -86,13 +86,13 @@ if not DEBUG:
         },
     },
     }
-    
+
     logging.config.dictConfig(LOGGING)
 
 
 # Application definition
 
-INSTALLED_APPS = [ 
+INSTALLED_APPS = [
     'corsheaders',
     'anymail',
     # 'daphne',
@@ -101,7 +101,7 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions', # legacy
     'django.contrib.messages',
-    'rest_framework', 
+    'rest_framework',
     'django.contrib.staticfiles',
     'mozilla_django_oidc',
     'university',
@@ -168,6 +168,8 @@ TEMPLATES = [
 
 
 WSGI_APPLICATION = 'tts_be.wsgi.application'
+
+ASGI_APPLICATION = 'tts_be.asgi.application'
 
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',

--- a/django/university/socket/views.py
+++ b/django/university/socket/views.py
@@ -20,7 +20,7 @@ async def emit_session_update(sid, session: Session):
         'session_id': session.session_id,
         'session_info': session.to_json(),
     }
-    
+
     await sessions_server.emit_to_session('update_session_info', payload, session.session_id, sid)
 
 @sessions_server.event
@@ -29,59 +29,51 @@ async def connect(sid, environ, auth):
         raise ConnectionRefusedError('Authentication failed: No token provided')
     if not sessions_server.valid_token(auth['token']):
         raise ConnectionRefusedError('Authentication failed: Invalid token')
-    
+
     print(f'Participant {sid} connected')
-    
+
     query_params = parse_qs(environ.get("QUERY_STRING", ""))
     session_id = query_params.get('session_id', [None])[0]
-    
+
     participant_name = query_params.get('participant_name', ["Anonymous"])[0]
     participant = Participant(sid, participant_name)
-    
+
     if session_id is None:
         await sessions_server.create_session(participant)
-    
+
         session = cast(Session, sessions_server.get_client_session(sid))
         session_id = session.session_id
-        
+
         print(f"Participant {sid} created session {session_id}")
-    else:     
+    else:
         await sessions_server.enter_session(participant, session_id)
 
         session = cast(Session, sessions_server.get_session(session_id))
-        
+
         print(f"Participant {sid} joined session {session_id}")
-    
+
     payload = {
         'client_id': participant.client_id,
         'session_id': session_id,
         'session_info': session.to_json(),
     }
-    
+
     await sessions_server.emit('connected', payload, to=sid)
     await emit_session_update(sid, session)
 
 @sessions_server.event
 async def disconnect(sid):
     session = cast(Session, sessions_server.get_client_session(sid))
-    
+
     await sessions_server.leave_session(sid)
     print(f'Client {sid} disconnected')
-    
+
     await emit_session_update(sid, session)
 
-# TODO: Remove this
-@sessions_server.event
-async def ping(sid, data):
-    user_session = cast(Session, sessions_server.get_client_session(sid))
-    session_id = user_session.session_id
-    
-    await sessions_server.emit_to_session('ping', data, session_id=session_id, sid=sid)
-    
 @sessions_server.event
 async def update_participant(sid, updated_participant):
     user_session = cast(Session, sessions_server.get_client_session(sid))
     participant = user_session.participants[sid]
     participant.update_from_json(updated_participant)
-    
+
     await emit_session_update(sid, user_session)


### PR DESCRIPTION
Closes #291 

## What does this PR do?

Restores the configurations that allow the collaborative sessions to run (such as activating the ASGI server and adding missing applications for WebSocket support). In addition, removes the obsolete "ping" socket.io event.

> [!NOTE]
> This PR is related to [#700](https://github.com/NIAEFEUP/tts-fe/pull/700) in the frontend.

## How to test

Start a session in the frontend and open the browser console. The session should be created successfully (green button) and there shouldn't appear any ping messages.
