### PR TITLE
Feat/store participants slot

### DIFF
--- a/django/university/socket/participant.py
+++ b/django/university/socket/participant.py
@@ -1,23 +1,27 @@
 import uuid
 
 class Participant:
-    def __init__(self, sid, name):
+    def __init__(self, sid, name, selected_slots):
         self.sid = sid
         self.client_id = str(uuid.uuid4())
         self.name = name
+        self.selected_slots = selected_slots or []
         
     def to_json(self):
         return {
             'client_id': self.client_id,
             'name': self.name,
+            'selected_slots': self.selected_slots,
         }
         
     @staticmethod
     def from_json(sid, data):
         if 'name' not in data:
             raise ValueError('name is required')
-        return Participant(sid, data['name'])
+        return Participant(sid, data['name'], data.get('selected_slots', []))
     
     def update_from_json(self, data):
         if 'name' in data:
             self.name = data['name']
+        if 'selected_slots' in data:
+            self.selected_slots = data['selected_slots']

--- a/django/university/socket/views.py
+++ b/django/university/socket/views.py
@@ -79,3 +79,12 @@ async def update_participant(sid, updated_participant):
     participant.update_from_json(updated_participant)
 
     await emit_session_update(sid, user_session)
+
+@sessions_server.event
+async def update_schedule(sid, selected_slots):
+    user_session = cast(Session, sessions_server.get_client_session(sid))
+    participant = user_session.participants[sid]
+
+    participant.selected_slots = selected_slots
+
+    await emit_session_update(sid, user_session)


### PR DESCRIPTION
Closes #279 

## What does this PR do?
To enable real-time schedule sync, each participant's selected slots are now tracked in memory on the server.
