### PR TITLE
Fix empty class schedules in dev by fetching live Sigarra data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ httpd/shibboleth/*.pem
 # Mock data for testing
 django/mock-data.json
 
+
+# macOS
+.DS_Store

--- a/django/university/controllers/ClassController.py
+++ b/django/university/controllers/ClassController.py
@@ -88,7 +88,10 @@ class ClassController:
                 )
                 SlotClass.objects.update_or_create(slot=slot, class_field=new_class)
 
-            for person in entry.get('persons', []):
+            # SlotProfessor.slot is the primary key, so the schema supports
+            # exactly one professor per slot. Real payloads can contain
+            # co-teachers; keep the primary (first) one like the old parser.
+            for person in entry.get('persons', [])[:1]:
                 sigarra_id = person.get('sigarra_id')
                 person_id = person.get('id')
                 professor, _ = Professor.objects.update_or_create(
@@ -199,14 +202,17 @@ class ClassController:
 
         if not cache.get(f"schedule-{course_unit_id}"):
             with transaction.atomic():
-                schedule = SigarraController().get_course_schedule(course_unit_id, new_schedule_api=new_schedule_api, faculty=course_unit.course.faculty.acronym).data
-                
-                if new_schedule_api:
-                    ClassController.parse_classes_from_response_new_api(schedule)
-                else:
-                    ClassController.parse_classes_from_response_old_api(schedule)
+                schedule_response = SigarraController().get_course_schedule(course_unit_id, new_schedule_api=new_schedule_api, faculty=course_unit.course.faculty.acronym)
 
-                cache.set(f"schedule-{course_unit_id}", True, CLASS_SCHEDULE_CACHE_TTL)
+                if schedule_response.status_code == 200 and schedule_response.data is not None:
+                    if new_schedule_api:
+                        ClassController.parse_classes_from_response_new_api(schedule_response.data)
+                    else:
+                        ClassController.parse_classes_from_response_old_api(schedule_response.data)
+
+                    # Only mark as fetched on success so failed lookups are retried
+                    # instead of serving empty data until the TTL expires.
+                    cache.set(f"schedule-{course_unit_id}", True, CLASS_SCHEDULE_CACHE_TTL)
         
         classes = Class.objects.filter(
             course_unit=course_unit_id

--- a/django/university/controllers/SigarraController.py
+++ b/django/university/controllers/SigarraController.py
@@ -8,6 +8,12 @@ from university.utils import sigarra_mock
 from datetime import date
 from tts_be.settings import CONFIG
 
+# Sigarra's WAF rejects requests with default Python user-agents (403).
+BROWSER_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36",
+    "Accept": "application/json,text/html;q=0.9,*/*;q=0.8",
+}
+
 class SigarraResponse:
     def __init__(self, data, status_code):
         self.data = data
@@ -23,19 +29,40 @@ class SigarraController:
         self.password = CONFIG["SIGARRA_PASSWORD"]
         self.cookies = None
         self.mock = int(CONFIG.get("MOCK_SIGARRA", "0"))
+        self._login_attempted = False
 
         if login and not self.mock:
             self.login()
 
     def make_get_request(self, url):
         if self.mock:
-            return sigarra_mock.get(url)
-        return requests.get(url, cookies=self.cookies)
-        
+            response = sigarra_mock.get(url)
+
+            # Captured entries are served as-is; anything else falls back to the
+            # live Sigarra so dev environments get real data like staging does.
+            if getattr(response, "status_code", 0) == 200:
+                return response
+
+            print(f"[sigarra] No captured mock entry; fetching live: {url}")
+
+        if not self._login_attempted:
+            self.login()
+
+        return requests.get(url, cookies=self.cookies, headers=BROWSER_HEADERS)
+
     def make_post_request(self, url, data = None):
         if self.mock:
-            return sigarra_mock.post(url, data)
-        return requests.post(url, data)
+            response = sigarra_mock.post(url, data)
+
+            if getattr(response, "status_code", 0) == 200:
+                return response
+
+            print(f"[sigarra] No captured mock entry; posting live: {url}")
+
+        if not self._login_attempted:
+            self.login()
+
+        return requests.post(url, data=data, headers=BROWSER_HEADERS)
 
     def get_student_photo_url(self, nmec) -> str:
         return f"https://sigarra.up.pt/feup/pt/fotografias_service.foto?pct_cod={nmec}"
@@ -100,11 +127,14 @@ class SigarraController:
         }, courses))
 
     def login(self):
+        if self._login_attempted:
+            return
+        self._login_attempted = True
         try:
-            response = self.make_post_request("https://sigarra.up.pt/feup/pt/vld_validacao.validacao", data={
+            response = requests.post("https://sigarra.up.pt/feup/pt/vld_validacao.validacao", data={
                 "p_user": self.username,
                 "p_pass": self.password
-            })
+            }, headers=BROWSER_HEADERS)
 
             self.cookies = response.cookies
         except requests.exceptions.RequestException as e:
@@ -148,6 +178,10 @@ class SigarraController:
         (semana_ini, semana_fim) = self.semester_weeks()
         schedule_controller = ScheduleController()
 
+        # Honor EXCHANGE_YEAR (like semester_weeks does) so dev/staging can pin
+        # the academic year whose timetables are actually published in Sigarra.
+        academic_year = CONFIG.get("EXCHANGE_YEAR", "") or schedule_controller.get_academic_year()
+
         response = self.make_get_request(self.course_unit_schedule_url(
             course_unit_id,
             semana_ini,
@@ -156,7 +190,7 @@ class SigarraController:
         ) if not new_schedule_api else ScheduleController().calendarios_api(
             faculty,
             course_unit_id,
-            schedule_controller.get_academic_year(),
+            academic_year,
             schedule_controller.get_period()
         ))
 

--- a/django/university/utils/sigarra_mock.py
+++ b/django/university/utils/sigarra_mock.py
@@ -48,13 +48,24 @@ def _load_mock() -> dict:
     except (json.JSONDecodeError, FileNotFoundError):
         return {"get": {}, "post": {}}
 
+def _strip_query(url: str) -> str:
+    parsed = urlparse(url)
+    return urlunparse(parsed._replace(query=""))
+
+
 def _get_mock_entry(store: dict, url: str) -> dict | None:
     entry = store.get(url)
-    if entry is None:
-        parsed = urlparse(url)
-        no_query = urlunparse(parsed._replace(query=""))
-        entry = store.get(no_query)
-    return entry
+    if entry is not None:
+        return entry
+
+    # Fall back to matching by path only, so that changes in query params
+    # (e.g. academic_year, week ranges) do not break lookups.
+    url_no_query = _strip_query(url)
+    for key, value in store.items():
+        if _strip_query(key) == url_no_query:
+            return value
+    return None
+
 
 def get(url: str):
     """Handles mocked GET requests."""
@@ -62,6 +73,7 @@ def get(url: str):
     entry = _get_mock_entry(store, url)
 
     if entry is None:
+        print(f"[sigarra-mock] No mock entry for GET {url}")
         return MockResponse(404, None)
 
     return MockResponse(entry.get("status_code", 200), entry.get("data"))
@@ -72,6 +84,7 @@ def post(url: str, data=None):
     entry = _get_mock_entry(store, url)
 
     if entry is None:
+        print(f"[sigarra-mock] No mock entry for POST {url}")
         return MockPostResponse(404, {})
 
     return MockPostResponse(entry.get("status_code", 200), entry.get("cookies", {}))

--- a/scripts/marketplace/make_mock.py
+++ b/scripts/marketplace/make_mock.py
@@ -1,11 +1,122 @@
 from __future__ import annotations
 
 import base64
+import http.cookiejar
 import json
+import urllib.error
+import urllib.parse
+import urllib.request
 
+from datetime import date
 from pathlib import Path
 
-import requests
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MOCK_DATA_PATH = REPO_ROOT / "django" / "mock-data.json"
+ENV_DEV_PATH = REPO_ROOT / "django" / ".env.dev"
+
+
+def load_env_config(path: Path) -> dict:
+    config = {}
+    if not path.exists():
+        return config
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            key, _, value = line.partition("=")
+            config[key.strip()] = value.strip()
+    return config
+
+
+CONFIG = load_env_config(ENV_DEV_PATH)
+
+
+def get_academic_year() -> str:
+    # Mirrors ScheduleController.get_academic_year(), honoring EXCHANGE_YEAR like SigarraController does.
+    exchange_year = CONFIG.get("EXCHANGE_YEAR")
+    if exchange_year:
+        return str(exchange_year)
+    currdate = date.today()
+    return str(currdate.year - 1 if currdate.month < 8 else currdate.year)
+
+
+def is_first_semester() -> bool:
+    semester = CONFIG.get("EXCHANGE_SEMESTER")
+    if semester:
+        return int(semester) == 1
+    currdate = date.today()
+    return currdate.month >= 10 or currdate.month <= 1
+
+
+def get_period() -> str:
+    # Mirrors ScheduleController.get_period(): period N+1 maps to semester N.
+    semester = CONFIG.get("EXCHANGE_SEMESTER")
+    if semester:
+        return f"{int(semester) + 1}"
+    return "2" if is_first_semester() else "3"
+
+
+def semester_weeks() -> tuple[str, str]:
+    # Mirrors SigarraController.semester_weeks().
+    year = get_academic_year()
+    if is_first_semester():
+        return (year + "1001", f"{int(year) + 1}0131")
+    return (year + "0210", year + "0601")
+
+
+SEMANA_INI, SEMANA_FIM = semester_weeks()
+ACADEMIC_YEAR = get_academic_year()
+PERIOD = get_period()
+
+
+class HTTPResponse:
+    def __init__(self, response):
+        self._headers = response.headers
+        self.status_code = getattr(response, "status", None) or response.code
+        body = response.read()
+        charset = response.headers.get_content_charset() or "utf-8"
+        self.content = body
+        self.text = body.decode(charset, errors="replace")
+
+    @property
+    def headers(self):
+        return self._headers
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            snippet = self.text[:300].strip()
+            raise RuntimeError(f"Request failed with status {self.status_code}: {snippet}")
+
+
+class HTTPSession:
+    """Minimal stdlib replacement for requests.Session: form posts + cookie persistence."""
+
+    # Sigarra rejects default Python user-agents with 403.
+    DEFAULT_HEADERS = {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36",
+        "Accept": "text/html,application/json;q=0.9,*/*;q=0.8",
+    }
+
+    def __init__(self):
+        cookie_jar = http.cookiejar.CookieJar()
+        self.opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cookie_jar))
+
+    def get(self, url):
+        request = urllib.request.Request(url, method="GET", headers=self.DEFAULT_HEADERS)
+        return self._open(request)
+
+    def post(self, url, data=None):
+        body = urllib.parse.urlencode(data or {}).encode("utf-8")
+        headers = {**self.DEFAULT_HEADERS, "Content-Type": "application/x-www-form-urlencoded"}
+        request = urllib.request.Request(url, data=body, method="POST", headers=headers)
+        return self._open(request)
+
+    def _open(self, request):
+        try:
+            response = self.opener.open(request)
+        except urllib.error.HTTPError as error:
+            response = error
+        return HTTPResponse(response)
+
 
 students = [
     "202307365",
@@ -45,19 +156,19 @@ sigarra_requests = {
     },
     "student_schedule": {
         "method": "GET",
-        "url": lambda nmec, semana_ini="20251001", semana_fim="20260131": (
+        "url": lambda nmec, semana_ini=SEMANA_INI, semana_fim=SEMANA_FIM: (
             f"https://sigarra.up.pt/feup/pt/mob_hor_geral.estudante?pv_codigo={nmec}&pv_semana_ini={semana_ini}&pv_semana_fim={semana_fim}"
         )
     },
     "course_unit_schedule": {
         "method": "GET",
-        "url": lambda ocorrencia_id, semana_ini="20251001", semana_fim="20260131", faculty="feup": (
+        "url": lambda ocorrencia_id, semana_ini=SEMANA_INI, semana_fim=SEMANA_FIM, faculty="feup": (
             f"https://sigarra.up.pt/{faculty}/pt/mob_hor_geral.ucurr?pv_ocorrencia_id={ocorrencia_id}&pv_semana_ini={semana_ini}&pv_semana_fim={semana_fim}"
         )
     },
     "course_unit_schedule_new": {
         "method": "GET",
-        "url": lambda faculty="feup", course_unit_id=None, year="2025", period="2": ( # period 2 means semester 1, it is really weird but it is that way
+        "url": lambda faculty="feup", course_unit_id=None, year=ACADEMIC_YEAR, period=PERIOD: ( # period N+1 means semester N
             f"https://sigarra.up.pt/calendarios-api/api/v1/events/{faculty}/uc/{course_unit_id}/?academic_year={year}&period={period}"
         )
     },
@@ -66,12 +177,6 @@ sigarra_requests = {
         "url": lambda course_unit_id: f"https://sigarra.up.pt/feup/pt/mob_ucurr_geral.uc_inscritos?pv_ocorrencia_id={course_unit_id}"
     }
 }
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
-MOCK_DATA_PATH = REPO_ROOT / "django" / "mock-data.json"
-
-
-
 
 def load_mock_store() -> dict:
     if MOCK_DATA_PATH.exists():
@@ -85,7 +190,7 @@ def data_uri(content_type: str, payload: bytes) -> str:
     return f"data:{content_type};base64,{encoded}"
 
 
-def serialize_response(method: str, url: str, response: requests.Response, store: dict, cookie_snapshot: dict | None = None) -> None:
+def serialize_response(method: str, url: str, response: HTTPResponse, store: dict) -> None:
     bucket = store.setdefault(method.lower(), {})
     entry: dict = {"status_code": response.status_code}
 
@@ -101,18 +206,18 @@ def serialize_response(method: str, url: str, response: requests.Response, store
     bucket[url] = entry
 
 
-def ensure_session() -> tuple[requests.Session, requests.Response]:
+def ensure_session() -> tuple[HTTPSession, HTTPResponse]:
     username = input("SIGARRA username: ")
     password = input("SIGARRA password: ")
 
-    session = requests.Session()
+    session = HTTPSession()
     login_url = sigarra_requests["login"]["url"]
     response = session.post(login_url, data={"p_user": username, "p_pass": password})
     response.raise_for_status()
     return session, response
 
 
-def fetch_all(session: requests.Session, store: dict, login_response: requests.Response) -> None:
+def fetch_all(session: HTTPSession, store: dict, login_response: HTTPResponse) -> None:
     serialize_response(
         "POST",
         sigarra_requests["login"]["url"],

--- a/scripts/marketplace/readme.md
+++ b/scripts/marketplace/readme.md
@@ -12,6 +12,8 @@ MOCK_SIGARRA=1
 
 After that, run the `make_mock.py` script, which generates a `mock-data.json` file. If you want to add more users or courses to the mock data, you can modify this script.
 
+**Note:** running `make_mock.py` is optional. When `MOCK_SIGARRA=1`, any URL without a captured entry is fetched live from Sigarra, using the `SIGARRA_USERNAME`/`SIGARRA_PASSWORD` credentials configured in your env file. Use the script only if you want fully offline mock data.
+
 When using mock Sigarra, you only have data for the following users and courses:
 
 ### Students


### PR DESCRIPTION
- Fall back to live Sigarra (lazy login) when MOCK_SIGARRA has no captured entry for a URL, so dev behaves like staging
- Send browser-like User-Agent: Sigarra WAF rejects default Python agents
- Honor EXCHANGE_YEAR in the new schedules API path
- Only cache the schedule-fetched flag on successful fetches
- Keep primary professor per slot to avoid UNIQUE constraint failures on co-taught lessons
- Match mock entries by path, ignoring query params
- make_mock.py: stdlib-only HTTP client; derive year/period from env
